### PR TITLE
Refactor Qodana workflow for configuration upload

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -1,35 +1,28 @@
-﻿name: Qodana
+name: Qodana Configuration Upload
+
 on:
-  workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - dev
-      - main
+    push:
+        branches: [ main, dev, feature ]
+    pull_request:
+        branches: [ main, dev ]
+    workflow_dispatch:
 
 jobs:
-  qodana:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      checks: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2025.2
-        env:
-          QODANA_TOKEN: ${{ secrets.eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0IjoiYjhieVkiLCJvcmdhbml6YXRpb24iOiI4RXdrYiIsInRva2VuIjoiZFhhR1EifQ.HTjHmSH6swIYsia6T8-3tL2wU5bqBJBYV4xgrmIUobk }}
-        with:
-          # When pr-mode is set to true, Qodana analyzes only the files that have been changed
-          pr-mode: false
-          use-caches: true
-          post-pr-comment: true
-          use-annotations: true
-          # Upload Qodana results (SARIF, other artifacts, logs) as an artifact to the job
-          upload-result: false
-          # quick-fixes available in Ultimate and Ultimate Plus plans
-          push-fixes: 'none'
+    upload-qodana-config:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Run Qodana Configuration Uploader
+              env:
+                  QODANA_CONFIGURATIONS_TOKEN: ${{ secrets.QODANA_CONFIGURATIONS_TOKEN }}
+                  QODANA_ENDPOINT: 'https://qodana.cloud'
+              run: |
+                  docker run --rm \
+                    -v $(pwd):/workspace \
+                    -w /workspace \
+                    -e QODANA_CONFIGURATIONS_TOKEN=$QODANA_CONFIGURATIONS_TOKEN \
+                    jetbrains/qodana-configuration-uploader:latest \
+                    --global-configs-file qodana-global-configurations.yaml


### PR DESCRIPTION
Updated Qodana workflow to include configuration upload step and modified event triggers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Replace Qodana scan with configuration upload**
> 
> - Replaces prior Qodana scan job using `JetBrains/qodana-action` with a single `upload-qodana-config` job that runs `jetbrains/qodana-configuration-uploader` via Docker to upload `qodana-global-configurations.yaml`.
> - Uses secrets-based `QODANA_CONFIGURATIONS_TOKEN` and sets `QODANA_ENDPOINT`.
> 
> **Workflow changes**
> 
> - Renames workflow to `Qodana Configuration Upload` and updates triggers in `.github/workflows/qodana_code_quality.yml` to run on `push` to `main`, `dev`, `feature`, `pull_request` to `main`/`dev`, and `workflow_dispatch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb99706939d39d36a7691bb36f4ec3e4a7d75575. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->