### PR TITLE
fix: Docker restore — include Directory.Packages.props (CPM)

### DIFF
--- a/CoffeePeek.AccountService/AccountService.Dockerfile
+++ b/CoffeePeek.AccountService/AccountService.Dockerfile
@@ -10,6 +10,7 @@ EXPOSE 80
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "."]
 COPY ["CoffeePeek.AccountService/CoffeePeek.AccountService.csproj", "CoffeePeek.AccountService/"]
 COPY ["CoffeePeek.Account.Infrastructure/CoffeePeek.Account.Infrastructure.csproj", "CoffeePeek.Account.Infrastructure/"]
 COPY ["CoffeePeek.Account.Application/CoffeePeek.Account.Application.csproj", "CoffeePeek.Account.Application/"]

--- a/CoffeePeek.Gateway/Gateway.Dockerfile
+++ b/CoffeePeek.Gateway/Gateway.Dockerfile
@@ -9,6 +9,7 @@ EXPOSE 80
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "."]
 COPY ["CoffeePeek.Gateway/CoffeePeek.Gateway.csproj", "CoffeePeek.Gateway/"]
 COPY ["CoffeePeek.Shared.Auth/CoffeePeek.Shared.Auth.csproj", "CoffeePeek.Shared.Auth/"]
 COPY ["CoffeePeek.Shared.Web/CoffeePeek.Shared.Web.csproj", "CoffeePeek.Shared.Web/"]

--- a/CoffeePeek.MediaService/MediaService.Dockerfile
+++ b/CoffeePeek.MediaService/MediaService.Dockerfile
@@ -7,6 +7,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "."]
 COPY ["CoffeePeek.MediaService/CoffeePeek.MediaService.csproj", "CoffeePeek.MediaService/"]
 COPY ["CoffeePeek.Shared.Auth/CoffeePeek.Shared.Auth.csproj", "CoffeePeek.Shared.Auth/"]
 COPY ["CoffeePeek.Shared.Web/CoffeePeek.Shared.Web.csproj", "CoffeePeek.Shared.Web/"]

--- a/CoffeePeek.ModerationService/ModerationService.Dockerfile
+++ b/CoffeePeek.ModerationService/ModerationService.Dockerfile
@@ -9,6 +9,7 @@ EXPOSE 80
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "."]
 COPY ["CoffeePeek.ModerationService/CoffeePeek.ModerationService.csproj", "CoffeePeek.ModerationService/"]
 COPY ["CoffeePeek.Moderation.Infrastructure/CoffeePeek.Moderation.Infrastructure.csproj", "CoffeePeek.Moderation.Infrastructure/"]
 COPY ["CoffeePeek.Moderation.Application/CoffeePeek.Moderation.Application.csproj", "CoffeePeek.Moderation.Application/"]

--- a/CoffeePeek.ShopsService/ShopsService.Dockerfile
+++ b/CoffeePeek.ShopsService/ShopsService.Dockerfile
@@ -7,6 +7,7 @@ EXPOSE 80
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Packages.props", "."]
 COPY ["CoffeePeek.ShopsService/CoffeePeek.ShopsService.csproj", "CoffeePeek.ShopsService/"]
 COPY ["CoffeePeek.Shops.Infrastructure/CoffeePeek.Shops.Infrastructure.csproj", "CoffeePeek.Shops.Infrastructure/"]
 COPY ["CoffeePeek.Shops.Application/CoffeePeek.Shops.Application.csproj", "CoffeePeek.Shops.Application/"]


### PR DESCRIPTION
## Problem
Push to `dev` failed in **build_and_push_images**: `dotnet restore` inside the Dockerfile context could not resolve package versions (NU1015), which cascaded into NU1107 conflicts because NuGet fell back to wrong versions.

## Cause
Projects use [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management) via `Directory.Packages.props`. The Docker build stage only copied `*.csproj` files, not that props file, so `PackageReference` items had no versions.

## Fix
Copy `Directory.Packages.props` to `/src` before `dotnet restore` in all five service Dockerfiles.

## Validation
- CI `build_and_test` already used full repo restore and was green; only image build was broken.
- Re-run the workflow on merge to confirm `build_and_push_images` succeeds.


Made with [Cursor](https://cursor.com)