### PR TITLE
fix: CodeRabbit (PR #188) + apply_migrations CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -21,12 +21,13 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Use user-local .NET install (workloads + cache)
+        run: echo "DOTNET_INSTALL_DIR=$HOME/.dotnet" >> "$GITHUB_ENV"
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
@@ -51,9 +52,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.dotnet
-          key: ${{ runner.os }}-dotnet-workloads-${{ hashFiles('**/*.csproj', 'global.json') }}
-          restore-keys: |
-            ${{ runner.os }}-dotnet-workloads-
+          key: ${{ runner.os }}-dotnet-wl-v2-${{ hashFiles('**/*.csproj', 'global.json', '**/*.props') }}
 
       - name: Restore .NET workloads
         run: dotnet workload restore "CoffeePeek.slnx"
@@ -63,7 +62,21 @@ jobs:
 
       - name: Audit dependencies
         continue-on-error: true
-        run: dotnet list "CoffeePeek.slnx" package --vulnerable --include-transitive
+        run: |
+          set -uo pipefail
+          set +e
+          report="$(dotnet list "CoffeePeek.slnx" package --vulnerable --include-transitive 2>&1)"
+          set -e
+          echo "$report"
+          {
+            echo "### Vulnerable packages report"
+            echo '```'
+            echo "$report"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if echo "$report" | grep -qiE '>\s*Project|has the following vulnerable'; then
+            echo "::warning::Vulnerable NuGet packages reported by dotnet list; see the step log and job summary"
+          fi
 
       - name: Build solution
         run: |
@@ -98,8 +111,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
-    permissions:
-      contents: read
 
     env:
       REGISTRY: docker.io
@@ -174,8 +185,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
-    permissions:
-      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -186,7 +195,17 @@ jobs:
           dotnet-version: '10.0.x'
           
       - name: Restore dependencies
-        run: dotnet restore "CoffeePeek.slnx" -p:AllowMissingPrunePackageData=true
+        run: |
+          set -euo pipefail
+          projects=(
+            "CoffeePeek.AccountService/CoffeePeek.AccountService.csproj"
+            "CoffeePeek.ShopsService/CoffeePeek.ShopsService.csproj"
+            "CoffeePeek.ModerationService/CoffeePeek.ModerationService.csproj"
+            "CoffeePeek.MediaService/CoffeePeek.MediaService.csproj"
+          )
+          for project in "${projects[@]}"; do
+            dotnet restore "$project" -p:AllowMissingPrunePackageData=true
+          done
   
       - name: Install dotnet-ef tool
         run: dotnet tool install --global dotnet-ef

--- a/CoffeePeek.Client.App.Infrastructure.HTTP/Requests/Moderation/ShopPhotoUploadRequest.cs
+++ b/CoffeePeek.Client.App.Infrastructure.HTTP/Requests/Moderation/ShopPhotoUploadRequest.cs
@@ -2,7 +2,7 @@ namespace CoffeePeek.Client.App.Infrastructure.HTTP.Requests.Moderation;
 
 public sealed class ShopPhotoUploadRequest
 {
-    public required int SizeBytes { get; init; }
+    public required long SizeBytes { get; init; }
 
     public required string FileName { get; init; }
 

--- a/CoffeePeek.Client.App.Infrastructure.HTTP/Requests/Profile/GenerateAvatarUploadUrlRequest.cs
+++ b/CoffeePeek.Client.App.Infrastructure.HTTP/Requests/Profile/GenerateAvatarUploadUrlRequest.cs
@@ -2,7 +2,7 @@ namespace CoffeePeek.Client.App.Infrastructure.HTTP.Requests.Profile;
 
 public sealed class GenerateAvatarUploadUrlRequest : BaseRequest
 {
-    public required int SizeBytes { get; init; }
+    public required long SizeBytes { get; init; }
 
     public required string FileName { get; init; }
 

--- a/CoffeePeek.Client.App.Infrastructure/WebClient/WebUserProfileClient.cs
+++ b/CoffeePeek.Client.App.Infrastructure/WebClient/WebUserProfileClient.cs
@@ -7,7 +7,9 @@ using CoffeePeek.Client.App.Infrastructure.HTTP.WebClients;
 using CoffeePeek.Contract.Dtos;
 using FluentResults;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
 
 namespace CoffeePeek.Client.App.Infrastructure.WebClient;
 
@@ -18,6 +20,31 @@ public sealed class WebUserProfileClient(
     : WebClientBase(httpCommandExecutor), IWebUserProfileClient
 {
     private const int FinalizeAvatarMaxAttempts = 3;
+
+    private const long MaxAvatarBytes = 10L * 1024 * 1024;
+
+    private static bool IsTransientFinalizeFailure(Result result)
+    {
+        if (result is null || !result.IsFailed)
+            return false;
+
+        var text = string.Join(" ", result.Errors.Select(e => e.Message));
+        if (text.Contains("canceled", StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (Regex.IsMatch(text, @"\b(408|429)\b", RegexOptions.None, TimeSpan.FromMilliseconds(200)))
+            return true;
+        if (Regex.IsMatch(text, @"\b5\d\d\b", RegexOptions.None, TimeSpan.FromMilliseconds(200)))
+            return true;
+        if (text.Contains("timeout", StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (text.Contains("temporarily", StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (text.Contains("connection", StringComparison.OrdinalIgnoreCase) &&
+            (text.Contains("refused", StringComparison.OrdinalIgnoreCase) ||
+             text.Contains("reset", StringComparison.OrdinalIgnoreCase)))
+            return true;
+        return false;
+    }
 
     public Task<Result<UserProfileDto>> GetPublicProfileAsync(
         Guid userId,
@@ -71,19 +98,22 @@ public sealed class WebUserProfileClient(
         if (string.IsNullOrWhiteSpace(fileName) || fileContent is null || fileContent.Length == 0)
             return Result.Fail("Avatar file is invalid.");
 
-        if (fileContent.LongLength > int.MaxValue)
-            return Result.Fail("Avatar file is too large.");
+        if (fileContent.LongLength > MaxAvatarBytes)
+            return Result.Fail("Avatar is too large (maximum 10 MB).");
 
         var safeContentType = string.IsNullOrWhiteSpace(contentType)
             ? "application/octet-stream"
             : contentType;
+
+        if (!MediaTypeHeaderValue.TryParse(safeContentType, out var mediaType))
+            return Result.Fail($"Invalid content type: {safeContentType}");
 
         var prepareCommand = new HttpCommand()
             .WithMethod(HttpMethod.Post)
             .WithEndpoint("api/Photos/avatar")
             .WithBody(new GenerateAvatarUploadUrlRequest
             {
-                SizeBytes = fileContent.Length,
+                SizeBytes = fileContent.LongLength,
                 FileName = fileName,
                 ContentType = safeContentType
             })
@@ -91,15 +121,12 @@ public sealed class WebUserProfileClient(
 
         var prepareResult = await Execute<GenerateUploadUrlResponseDto>(prepareCommand, ct);
         if (prepareResult.IsFailed)
-            return Result.Fail(prepareResult.Errors);
+            return prepareResult.ToResult();
 
         using var putRequest = new HttpRequestMessage(HttpMethod.Put, prepareResult.Value.UploadUrl)
         {
             Content = new ByteArrayContent(fileContent)
         };
-
-        if (!MediaTypeHeaderValue.TryParse(safeContentType, out var mediaType))
-            return Result.Fail($"Invalid content type: {safeContentType}");
         putRequest.Content.Headers.ContentType = mediaType;
 
         using var putResponse = await httpClient.SendAsync(putRequest, ct);
@@ -112,10 +139,10 @@ public sealed class WebUserProfileClient(
             .WithBody(new UpdateAvatarRequest
             {
                 UploadedPhoto = new UploadedPhotoDto(
-                    fileName,
-                    safeContentType,
-                    prepareResult.Value.StorageKey,
-                    fileContent.LongLength)
+                    FileName: fileName,
+                    ContentType: safeContentType,
+                    StorageKey: prepareResult.Value.StorageKey,
+                    Size: fileContent.LongLength)
             })
             .Authorize();
 
@@ -129,6 +156,8 @@ public sealed class WebUserProfileClient(
 
             lastError = finalizeResult;
             if (attempt == FinalizeAvatarMaxAttempts)
+                break;
+            if (!IsTransientFinalizeFailure(finalizeResult))
                 break;
 
             var baseDelayMs = 200 * (1 << (attempt - 1));

--- a/CoffeePeek.Client.App.Tests/ViewModels/Home/UserProfileEditTests.cs
+++ b/CoffeePeek.Client.App.Tests/ViewModels/Home/UserProfileEditTests.cs
@@ -201,7 +201,30 @@ public class UserProfileEditTests
     [Fact]
     public async Task UploadAvatar_CallsProfileClientAndReloads()
     {
-        SetupProfileSuccess("user", "bio");
+        var profileCalls = 0;
+        _profileClientMock
+            .Setup(c => c.GetPublicProfileAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                profileCalls++;
+                return Result.Ok(new UserProfileDto
+                {
+                    UserName = profileCalls >= 2 ? "after-avatar" : "before-avatar",
+                    Email = "test@test.com",
+                    About = "bio",
+                    CreatedAtUtc = new DateTime(2024, 1, 1),
+                    ReviewCount = 5,
+                    CheckInCount = 3
+                });
+            });
+        _reviewsClientMock
+            .Setup(c => c.GetReviewsAsync(It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok(new GetReviewsByUserIdResultDto
+            {
+                ReviewDtos = [],
+                TotalPages = 1,
+                CurrentPage = 1
+            }));
         _imagePickerMock
             .Setup(x => x.PickImageAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PickedImageFile("avatar.jpg", "image/jpeg", [1, 2, 3]));
@@ -211,6 +234,7 @@ public class UserProfileEditTests
 
         var sut = CreateSut(OwnUserId);
         await sut.LoadAsync(OwnUserId);
+        sut.UserName.Should().Be("before-avatar");
 
         await sut.UploadAvatarCommand.ExecuteAsync(null);
 
@@ -220,6 +244,7 @@ public class UserProfileEditTests
         _profileClientMock.Verify(
             c => c.GetPublicProfileAsync(OwnUserId, It.IsAny<CancellationToken>()),
             Times.AtLeast(2));
+        sut.UserName.Should().Be("after-avatar");
         sut.IsUploadingAvatar.Should().BeFalse();
         sut.HasAvatarUploadError.Should().BeFalse();
     }

--- a/CoffeePeek.Client.App.Tests/WebClient/WebUserProfileClientTests.cs
+++ b/CoffeePeek.Client.App.Tests/WebClient/WebUserProfileClientTests.cs
@@ -195,6 +195,20 @@ public class WebUserProfileClientTests
     }
 
     [Fact]
+    public async Task UploadAvatarAsync_ReturnsFailure_WhenContentTypeInvalid()
+    {
+        var sut = CreateSut();
+        var result = await sut.UploadAvatarAsync("a.jpg", "not a real media type", [1, 2, 3]);
+
+        result.IsFailed.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e => e.Message.Contains("Invalid content type", StringComparison.Ordinal));
+        _executorMock.Verify(
+            e => e.Execute<GenerateUploadUrlResponseDto>(It.IsAny<HttpCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _httpMessageHandler.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
     public async Task UploadAvatarAsync_ReturnsFailure_WhenFileNameIsEmpty()
     {
         var sut = CreateSut();

--- a/CoffeePeek.Client.App/Resources/Lang/Resources.Designer.cs
+++ b/CoffeePeek.Client.App/Resources/Lang/Resources.Designer.cs
@@ -663,6 +663,12 @@ namespace CoffeePeek.Client.App.Resources.Lang {
             }
         }
 
+        public static string Profile_AvatarUploading {
+            get {
+                return ResourceManager.GetString("Profile_AvatarUploading", resourceCulture);
+            }
+        }
+
         public static string Profile_AvatarUploadError {
             get {
                 return ResourceManager.GetString("Profile_AvatarUploadError", resourceCulture);

--- a/CoffeePeek.Client.App/Resources/Lang/Resources.resx
+++ b/CoffeePeek.Client.App/Resources/Lang/Resources.resx
@@ -325,10 +325,13 @@
         <value>Username cannot be empty</value>
     </data>
     <data name="Profile_AvatarUpload" xml:space="preserve">
-        <value>Загрузить аватар</value>
+        <value>Upload avatar</value>
+    </data>
+    <data name="Profile_AvatarUploading" xml:space="preserve">
+        <value>Uploading…</value>
     </data>
     <data name="Profile_AvatarUploadError" xml:space="preserve">
-        <value>Не удалось загрузить аватар</value>
+        <value>Failed to upload avatar</value>
     </data>
     <data name="ShopPage_FilterBeans" xml:space="preserve">
         <value>Coffee Beans</value>

--- a/CoffeePeek.Client.App/Resources/Lang/Resources.ru.resx
+++ b/CoffeePeek.Client.App/Resources/Lang/Resources.ru.resx
@@ -191,6 +191,9 @@
     <data name="Profile_AvatarUploadError" xml:space="preserve">
         <value>Не удалось загрузить аватар</value>
     </data>
+    <data name="Profile_AvatarUploading" xml:space="preserve">
+        <value>Загрузка…</value>
+    </data>
     <data name="ShopPage_FilterBeans" xml:space="preserve">
         <value>Зёрна</value>
     </data>

--- a/CoffeePeek.Client.App/Services/ImagePickerService.cs
+++ b/CoffeePeek.Client.App/Services/ImagePickerService.cs
@@ -32,12 +32,14 @@ public sealed class ImagePickerService : IImagePickerService
 
         ct.ThrowIfCancellationRequested();
         var properties = await file.GetBasicPropertiesAsync();
-        if (properties.Size > MaxImageBytes)
+        if (properties.Size is { } knownSize && knownSize > MaxImageBytes)
             return null;
 
         await using var stream = await file.OpenReadAsync();
         await using var ms = new MemoryStream();
         await stream.CopyToAsync(ms, ct);
+        if ((ulong)ms.Length > MaxImageBytes)
+            return null;
 
         var fileName = file.Name ?? "avatar";
         var contentType = GetContentTypeFromExtension(fileName);

--- a/CoffeePeek.Client.App/ViewModels/Home/UserProfileViewModel.cs
+++ b/CoffeePeek.Client.App/ViewModels/Home/UserProfileViewModel.cs
@@ -146,6 +146,8 @@ public partial class UserProfileViewModel(
         _loadCts?.Dispose();
         _loadCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         _avatarUploadCts?.Cancel();
+        _avatarUploadCts?.Dispose();
+        _avatarUploadCts = null;
         var ct = _loadCts.Token;
 
         var currentUserId = identityAccessor.GetCurrentUserIdOrNull();
@@ -463,12 +465,13 @@ public partial class UserProfileViewModel(
         if (!IsOwnProfile || _userId is null)
             return;
 
-        AvatarUploadErrorMessage = null;
-        IsUploadingAvatar = true;
         _avatarUploadCts?.Cancel();
         _avatarUploadCts?.Dispose();
         _avatarUploadCts = CancellationTokenSource.CreateLinkedTokenSource(_loadCts?.Token ?? CancellationToken.None);
         var ct = _avatarUploadCts.Token;
+
+        AvatarUploadErrorMessage = null;
+        IsUploadingAvatar = true;
 
         try
         {
@@ -489,7 +492,9 @@ public partial class UserProfileViewModel(
                 return;
             }
 
-            await LoadAsync(_userId.Value, ct);
+            // Reload must not use the avatar upload token: LoadAsync cancels _loadCts, which
+            // would cascade-cancel a linked _avatarUploadCts and skip the profile refresh.
+            await LoadAsync(_userId.Value);
         }
         catch (OperationCanceledException)
         {
@@ -521,6 +526,8 @@ public partial class UserProfileViewModel(
     private async Task SignOutAsync()
     {
         _avatarUploadCts?.Cancel();
+        _avatarUploadCts?.Dispose();
+        _avatarUploadCts = null;
         workspaceShellNavigator.CloseUserProfile();
         _ = await authenticationClient.Logout();
         clientSession.Clear();

--- a/CoffeePeek.Client.App/Views/Home/UserProfileView.axaml
+++ b/CoffeePeek.Client.App/Views/Home/UserProfileView.axaml
@@ -154,6 +154,11 @@
                                     Padding="12,4" />
                                 <TextBlock
                                     FontSize="12"
+                                    Foreground="{DynamicResource OnSurfaceVariantBrush}"
+                                    IsVisible="{Binding IsUploadingAvatar}"
+                                    Text="{x:Static lang:Resources.Profile_AvatarUploading}" />
+                                <TextBlock
+                                    FontSize="12"
                                     Foreground="{DynamicResource AuthErrorForegroundBrush}"
                                     IsVisible="{Binding HasAvatarUploadError}"
                                     Text="{Binding AvatarUploadErrorMessage}"


### PR DESCRIPTION
## Summary
Addresses CodeRabbit review on [`#188`](https://github.com/CoffeePeek/CoffeePeek-NET/pull/188) and fixes the failing **`apply_migrations`**.

## CI
- **`apply_migrations`** was running `dotnet restore CoffeePeek.slnx`, which pulled the Android project and failed with `NETSDK1147` (workload not installed in that job). Restore now targets only the four backend service `.csproj` files, matching the subsequent build.
- `concurrency`: `cancel-in-progress` only for `pull_request` (avoid cancelling push runs mid-migration).
- Removed redundant per-job `permissions` (inherit workflow-level).
- `DOTNET_INSTALL_DIR` for install under `~` and workload cache key without unsafe `restore-keys`.
- Audit step: writes vulnerable-package output to the job summary and emits a `::warning` when findings are present.

## Avatar / profile (CodeRabbit)
- Client DTOs: `SizeBytes` as `long` where appropriate; `WebUserProfileClient`: max size, validate content type before prepare, `ToResult()`, `UploadedPhotoDto` named args, **transient-only** finalize retries, improved logging path unchanged.
- `UserProfileViewModel`: `LoadAsync` after successful upload no longer uses the avatar CTS (fixes cancel/reload bug); proper dispose of `\_avatarUploadCts` on load and sign-out; CTS setup before UI flags in upload.
- `ImagePickerService`: reject oversize when size known; always validate `MemoryStream` length after read.
- `Resources.resx`: English defaults for neutral culture; new `Profile_AvatarUploading` + RU; `UserProfileView.axaml` shows uploading state.

## Tests
- stronger upload/reload test; new invalid content-type test.

Merge into `dev` first, then rebase/update `#188` (`dev` → `main`).

**Note:** I did not add optional items (Stream-based upload API, full retry/cancellation test matrix, `IDisposable` on test HttpClient) to keep the diff reviewable; say if you want a follow-up PR.


Made with [Cursor](https://cursor.com)