### PR TITLE
ci: Deploy browser WASM to Vercel (#195)

### DIFF
--- a/.github/workflows/deploy-browser-vercel.yml
+++ b/.github/workflows/deploy-browser-vercel.yml
@@ -1,0 +1,94 @@
+name: Deploy Browser → Vercel
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - 'CoffeePeek.Client.App.Browser/**'
+      - 'CoffeePeek.Client.App/**'
+      - 'CoffeePeek.Client.App.Core/**'
+      - 'CoffeePeek.Client.App.Infrastructure/**'
+      - 'CoffeePeek.Client.App.Infrastructure.HTTP/**'
+      - 'CoffeePeek.Contract/**'
+      - 'CoffeePeek.Shared.Kernel/**'
+      - 'Directory.Packages.props'
+      - 'CoffeePeek.slnx'
+      - 'global.json'
+      - '.github/workflows/deploy-browser-vercel.yml'
+
+  workflow_dispatch:
+
+concurrency:
+  group: browser-vercel-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy_browser:
+    name: Publish WASM & deploy static app
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use user-local .NET install (workloads + cache)
+        run: echo "DOTNET_INSTALL_DIR=$HOME/.dotnet" >> "$GITHUB_ENV"
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Java SDK (workloads)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props', 'global.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Cache .NET workloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.dotnet
+          key: ${{ runner.os }}-dotnet-wl-deploy-browser-${{ hashFiles('global.json') }}
+          restore-keys: |
+            ${{ runner.os }}-dotnet-wl-deploy-browser-
+            ${{ runner.os }}-dotnet-wl-
+
+      - name: Restore .NET workloads
+        run: dotnet workload restore "CoffeePeek.slnx"
+
+      - name: Restore & publish browser (Release)
+        run: |
+          set -euo pipefail
+          dotnet restore "CoffeePeek.slnx" -p:AllowMissingPrunePackageData=true
+          dotnet publish \
+            "CoffeePeek.Client.App.Browser/CoffeePeek.Client.App.Browser.csproj" \
+            --configuration Release \
+            --no-restore \
+            -o ./dist \
+            -p:AllowMissingPrunePackageData=true
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: dist/wwwroot
+          production: ${{ github.ref == 'refs/heads/main' }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary\nAdds a GitHub Actions workflow that builds `CoffeePeek.Client.App.Browser` in **Release**, publishes output to `./dist/wwwroot`, and deploys those static assets to **Vercel** using \`amondnet/vercel-action@v25\`.\n\n### Triggers\n- **Push** to \`dev\` or \`main\`, only when paths touch the Avalonia/browser client dependency graph (or this workflow)\n- **workflow_dispatch** (manual rerun)\n\n### Behaviour\n- **\`production: true\`** only for \`refs/heads/main\` (production deployment on Vercel)\n- **Preview** deployments for pushes to \`dev\`\n\n### Required repository secrets\nConfigure in **GitHub → Settings → Secrets**: \`VERCEL_TOKEN\`, \`VERCEL_ORG_ID\`, \`VERCEL_PROJECT_ID\`. Details: https://github.com/CoffeePeek/CoffeePeek-NET/issues/195\n\n### Follow-up outside this PR\n- Production Gateway URL in client \`appsettings\` / env-specific config\n- CORS allowlist on the Gateway for the Vercel origin\n\nRefs #195