### PR TITLE
fix(shops): register RabbitMQ consumer for ModerationShopApprovedEvent

### DIFF
--- a/CoffeePeek.Shared.Persistence/Extensions/WolverineModule.cs
+++ b/CoffeePeek.Shared.Persistence/Extensions/WolverineModule.cs
@@ -22,11 +22,7 @@ public static class WolverineModule
             
             builder.Host.UseWolverine(opts =>
             {
-                if (builder.Environment.IsDevelopment())
-                {
-                    opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Auto;
-                }
-
+                opts.CodeGeneration.TypeLoadMode = TypeLoadMode.Auto;
 
                 opts.UseRabbitMq(o =>
                     {

--- a/CoffeePeek.Shops.Infrastructure/Consumers/CoffeeShopApprovedEventHandler.cs
+++ b/CoffeePeek.Shops.Infrastructure/Consumers/CoffeeShopApprovedEventHandler.cs
@@ -5,16 +5,14 @@ using Microsoft.Extensions.Logging;
 
 namespace CoffeePeek.Shops.Infrastructure.Consumers;
 
-public static class ModerationShopApproveHandler
+public class ModerationShopApproveHandler(
+    ICreateShopFromModerationService createShopService,
+    ILogger<ModerationShopApproveHandler> logger)
 {
-    public static async Task<ModerationShopApproveCompleteResponse> Handle(
+    public async Task<ModerationShopApproveCompleteResponse> Handle(
         ModerationShopApprovedEvent message,
-        ICreateShopFromModerationService createShopService,
-        ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
-        var logger = loggerFactory.CreateLogger(nameof(ModerationShopApproveHandler));
-
         logger.LogInformation(
             "Received ModerationShopApprovedEvent for moderation shop {ModerationShopId} ({ShopName})",
             message.Shop.Id,

--- a/CoffeePeek.Shops.Infrastructure/DependencyInjection.cs
+++ b/CoffeePeek.Shops.Infrastructure/DependencyInjection.cs
@@ -1,3 +1,4 @@
+using CoffeePeek.Shops.Infrastructure.Consumers;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CoffeePeek.Shops.Infrastructure;
@@ -6,8 +7,8 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddInfrastructure(this IServiceCollection services)
     {
+        services.AddScoped<ModerationShopApproveHandler>();
 
         return services;
     }
 }
-


### PR DESCRIPTION
Shops never subscribed to the fanout exchange in Production because TypeLoadMode.Static had no pre-generated listener for the event handler. Use TypeLoadMode.Auto and register ModerationShopApproveHandler in DI like Account service event consumers.