### PR TITLE
fix(messaging): use handler-type RabbitMQ queues for fanout subscribers

### DIFF
--- a/CoffeePeek.Shared.Persistence/Extensions/WolverineModule.cs
+++ b/CoffeePeek.Shared.Persistence/Extensions/WolverineModule.cs
@@ -8,6 +8,7 @@ using Wolverine;
 using Wolverine.EntityFrameworkCore;
 using Wolverine.Postgresql;
 using Wolverine.RabbitMQ;
+using Wolverine.Transports;
 
 namespace CoffeePeek.Shared.Persistence.Extensions;
 
@@ -35,8 +36,8 @@ public static class WolverineModule
                         o.Port = rabbitMqOptions.Port;
                     })
                     .AutoProvision()
-                    // Required for cross-service events (e.g. Moderation -> Shops).
-                    .UseConventionalRouting();
+                    // Each handler gets its own queue (Account + Shops both listen to ModerationShopApprovedEvent).
+                    .UseConventionalRouting(NamingSource.FromHandlerType);
 
                 opts.PersistMessagesWithPostgresql(postgresCpOptions.ConnectionString);
                 opts.UseEntityFrameworkCoreTransactions();

--- a/CoffeePeek.Shops.Application.Tests/Services/CreateShopFromModerationServiceTests.cs
+++ b/CoffeePeek.Shops.Application.Tests/Services/CreateShopFromModerationServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using CoffeePeek.Contract.Dtos.CoffeeShop;
+using CoffeePeek.Shared.Domain.Interfaces.Infrastructure;
 using CoffeePeek.Shared.Kernel;
 using CoffeePeek.Shops.Application.Services;
 using CoffeePeek.Shops.Domain.Aggregates.CoffeeShopAggregate;
@@ -19,6 +20,7 @@ public class CreateShopFromModerationServiceTests
     private readonly Mock<IQueryRoasterRepository> _roasterRepoMock = new();
     private readonly Mock<IQueryBrewMethodRepository> _brewMethodRepoMock = new();
     private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ICacheService> _cacheServiceMock = new();
     private readonly Mock<ILogger<CreateShopFromModerationService>> _loggerMock = new();
     private readonly CancellationToken _ct = CancellationToken.None;
 
@@ -30,6 +32,7 @@ public class CreateShopFromModerationServiceTests
             _roasterRepoMock.Object,
             _brewMethodRepoMock.Object,
             _unitOfWorkMock.Object,
+            _cacheServiceMock.Object,
             _loggerMock.Object);
 
     private static ShopDto CreateMinimalShopDto() =>

--- a/CoffeePeek.Shops.Application/Services/CreateShopFromModerationService.cs
+++ b/CoffeePeek.Shops.Application/Services/CreateShopFromModerationService.cs
@@ -1,4 +1,5 @@
 using CoffeePeek.Contract.Dtos.CoffeeShop;
+using CoffeePeek.Shared.Domain.Interfaces.Infrastructure;
 using CoffeePeek.Shared.Kernel;
 using CoffeePeek.Shops.Domain.Aggregates.CoffeeShopAggregate;
 using CoffeePeek.Shops.Domain.Entities;
@@ -13,6 +14,7 @@ public class CreateShopFromModerationService(
     IQueryRoasterRepository roasterRepository,
     IQueryBrewMethodRepository brewMethodRepository,
     IUnitOfWork unitOfWork,
+    ICacheService cacheService,
     ILogger<CreateShopFromModerationService> logger) : ICreateShopFromModerationService
 {
     public async Task<Guid> CreateShopFromApprovedEventAsync(ShopDto shopDto, Guid creatorId, Guid moderationId, CancellationToken cancellationToken = default)
@@ -91,6 +93,9 @@ public class CreateShopFromModerationService(
 
         shopRepository.Add(shop);
         await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        await cacheService.RemoveByPattern("shop:search:*", cancellationToken);
+        await cacheService.RemoveByPattern("shop:list:city:*", cancellationToken);
 
         logger.LogInformation("Shop {ShopId} successfully created from moderation event {ModerationId}", shop.Id,
             moderationId);


### PR DESCRIPTION
Account and Shops both handle ModerationShopApprovedEvent but shared one queue name, so only one service received each approve message. Name listener queues after handler type and invalidate shop search cache on create.