### PR TITLE
fix(account): reduce Sentry noise on refresh token failures

### DIFF
--- a/CoffeePeek.AccountService/Controllers/TokensController.cs
+++ b/CoffeePeek.AccountService/Controllers/TokensController.cs
@@ -4,6 +4,7 @@ using CoffeePeek.Account.Application.Features.Auth.OAuthLogin;
 using CoffeePeek.Account.Application.Features.Auth.RefreshToken;
 using CoffeePeek.Shared.Auth;
 using CoffeePeek.Shared.Auth.Options;
+using CoffeePeek.Shared.Kernel.Exceptions;
 using CoffeePeek.Shared.Kernel.Response;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -86,12 +87,25 @@ public class TokensController(
 
         var command = new RefreshTokenCommand(refreshToken, deviceName, ipAddress);
 
-        var response = await bus.InvokeAsync<Response<RefreshTokenResponse>>(command);
+        try
+        {
+            var response = await bus.InvokeAsync<Response<RefreshTokenResponse>>(command);
 
-        if (response.IsSuccess && response.Data is not null)
-            Response.Cookies.Append("refreshToken", response.Data.RefreshToken, CreateRefreshTokenCookieOptions());
+            if (response.IsSuccess && response.Data is not null)
+                Response.Cookies.Append("refreshToken", response.Data.RefreshToken, CreateRefreshTokenCookieOptions());
 
-        return Ok(response);
+            return Ok(response);
+        }
+        catch (UnauthorizedException)
+        {
+            DeleteRefreshTokenCookie();
+            throw;
+        }
+        catch (DomainException ex) when (ex.Message.Contains("Security breach", StringComparison.Ordinal))
+        {
+            DeleteRefreshTokenCookie();
+            throw;
+        }
     }
 
     /// <summary>
@@ -120,6 +134,16 @@ public class TokensController(
         HttpOnly = true,
         Secure = true,
         SameSite = SameSiteMode.Strict,
+        Path = "/",
         Expires = DateTimeOffset.UtcNow.AddDays(jwtOptions.Value.RefreshTokenLifetimeDays)
     };
+
+    private void DeleteRefreshTokenCookie() =>
+        Response.Cookies.Delete("refreshToken", new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = true,
+            SameSite = SameSiteMode.Strict,
+            Path = "/"
+        });
 }

--- a/CoffeePeek.AccountService/DependencyInjection.cs
+++ b/CoffeePeek.AccountService/DependencyInjection.cs
@@ -1,6 +1,7 @@
 ﻿using Asp.Versioning.ApiExplorer;
 using CoffeePeek.Account.Infrastructure.Consumers;
 using CoffeePeek.Account.Persistence.Configuration;
+using CoffeePeek.AccountService.Extensions;
 using CoffeePeek.Shared.Auth.Constants;
 using CoffeePeek.Shared.Auth.Extensions;
 using CoffeePeek.Shared.Kernel.Extentions;
@@ -40,7 +41,7 @@ public static class DependencyInjection
     public static IWebHostBuilder ConfigureWebhost(this IWebHostBuilder builder)
     {
         builder.ConfigureEnvironment();
-        builder.UseSentry();
+        builder.UseSentry(options => options.SetBeforeSend(SentryExtensions.FilterExpectedClientErrors));
         return builder;
     }
 }

--- a/CoffeePeek.AccountService/Extensions/SentryExtensions.cs
+++ b/CoffeePeek.AccountService/Extensions/SentryExtensions.cs
@@ -1,0 +1,29 @@
+using CoffeePeek.Shared.Kernel.Exceptions;
+using Sentry;
+
+namespace CoffeePeek.AccountService.Extensions;
+
+internal static class SentryExtensions
+{
+    /// <summary>
+    /// Drops expected client/auth failures from Sentry — they are handled and returned as 4xx responses.
+    /// </summary>
+    public static SentryEvent? FilterExpectedClientErrors(SentryEvent sentryEvent, SentryHint hint)
+    {
+        switch (sentryEvent.Exception)
+        {
+            case UnauthorizedException:
+            case ForbiddenException:
+            case NotFoundException:
+            case ValidationException:
+            case ConflictException:
+                return null;
+            case BaseException { StatusCode: >= 400 and < 500 }:
+                return null;
+            case DomainException domain when domain.Message.Contains("Security breach", StringComparison.Ordinal):
+                return null;
+        }
+
+        return sentryEvent;
+    }
+}

--- a/CoffeePeek.Shared.Web/Handlers/GlobalExceptionHandler.cs
+++ b/CoffeePeek.Shared.Web/Handlers/GlobalExceptionHandler.cs
@@ -18,13 +18,22 @@ public class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger, IWeb
         CancellationToken cancellationToken)
     {
         var traceId = httpContext.TraceIdentifier;
-
-        logger.LogError(
-            exception,
-            "Exception occurred: {Message}. TraceId: {TraceId}",
-            exception.Message, traceId);
-
         var statusCode = GetStatusCode(exception);
+
+        if (statusCode < StatusCodes.Status500InternalServerError)
+        {
+            logger.LogWarning(
+                exception,
+                "Client error ({StatusCode}): {Message}. TraceId: {TraceId}",
+                statusCode, exception.Message, traceId);
+        }
+        else
+        {
+            logger.LogError(
+                exception,
+                "Exception occurred: {Message}. TraceId: {TraceId}",
+                exception.Message, traceId);
+        }
         var errorCode = GetErrorCode(exception);
         var fieldErrors = (exception as ValidationException)?.Errors;
 


### PR DESCRIPTION
## Summary
- Downgrade expected 4xx exceptions to `LogWarning` in `GlobalExceptionHandler` so they no longer trigger Sentry (`MinimumEventLevel: Warning`).
- Add `SetBeforeSend` filter on Account Service to drop handled client/auth errors (`UnauthorizedException`, other 4xx `BaseException`, token reuse).
- Clear stale `refreshToken` cookie on refresh 401 / security-breach and set cookie `Path = "/"` for consistent browser behavior.

## Test plan
- [x] `dotnet build CoffeePeek.AccountService`
- [x] `dotnet test CoffeePeek.Account.Application.Tests --filter RefreshToken`
- [ ] Deploy to staging and confirm `PUT /api/Tokens` with invalid cookie returns 401 without Sentry event
- [ ] Confirm valid refresh still rotates token and updates cookie


Made with [Cursor](https://cursor.com)