### PR TITLE
fix(deploy): pull CI images on VPS to prevent SSH timeout

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -144,8 +144,10 @@ jobs:
         env:
           VPS_HOST: ${{ secrets.VPS_HOST }}
           VPS_USER: ${{ secrets.VPS_USER }}
+          SSH_OPTS: "-o ServerAliveInterval=30 -o ServerAliveCountMax=120 -o ConnectTimeout=30"
         run: |
           rsync -az --delete \
+            -e "ssh ${SSH_OPTS}" \
             --exclude '.git' \
             --exclude '**/bin' \
             --exclude '**/obj' \
@@ -158,8 +160,9 @@ jobs:
           VPS_USER: ${{ secrets.VPS_USER }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          SSH_OPTS: "-o ServerAliveInterval=30 -o ServerAliveCountMax=120 -o ConnectTimeout=30"
         run: |
-          ssh "${VPS_USER}@${VPS_HOST}" \
+          ssh ${SSH_OPTS} "${VPS_USER}@${VPS_HOST}" \
             "export DOCKER_HUB_USERNAME='${DOCKER_HUB_USERNAME}'; \
              export DOCKER_HUB_PASSWORD='${DOCKER_HUB_PASSWORD}'; \
              set -euo pipefail; \

--- a/deploy/scripts/update.sh
+++ b/deploy/scripts/update.sh
@@ -40,14 +40,31 @@ wait_for_backend() {
   return 1
 }
 
-echo "==> Building backend services..."
-"${COMPOSE[@]}" up -d --build account shops moderation media
+use_registry_images=false
+if [[ -n "${DOCKER_HUB_USERNAME:-}" && -n "${DOCKER_HUB_PASSWORD:-}" ]]; then
+  use_registry_images=true
+fi
+
+if [[ "${use_registry_images}" == "true" ]]; then
+  echo "==> Pulling backend images from Docker Hub..."
+  "${COMPOSE[@]}" pull account shops moderation media
+  echo "==> Starting backend services..."
+  "${COMPOSE[@]}" up -d account shops moderation media
+else
+  echo "==> Building backend services (no registry credentials)..."
+  "${COMPOSE[@]}" up -d --build account shops moderation media
+fi
 
 wait_for_backend shops /api/Catalogs/cities
 wait_for_backend account /health
 
 echo "==> Starting gateway and caddy..."
-"${COMPOSE[@]}" up -d --build gateway caddy
+if [[ "${use_registry_images}" == "true" ]]; then
+  "${COMPOSE[@]}" pull gateway
+  "${COMPOSE[@]}" up -d gateway caddy
+else
+  "${COMPOSE[@]}" up -d --build gateway caddy
+fi
 
 echo "==> Health check..."
 sleep 3


### PR DESCRIPTION
## Summary
- **Root cause:** merge Dev #218 → main failed in `deploy_vps` after ~8 min with `client_loop: send disconnect: Broken pipe`. CI had already built/pushed images, but VPS ran `docker compose up -d --build` for all 5 services — SSH died mid-build.
- **Fix:** when Docker Hub credentials are present (CI deploy), `update.sh` now `pull` + `up -d` instead of `--build`. Local/manual deploy without credentials still builds on VPS.
- **Safety net:** SSH keepalive (`ServerAliveInterval=30`) on rsync/ssh in CI.

## Test plan
- [ ] Merge to `dev`, then merge `dev` → `main`
- [ ] Confirm `deploy_vps` completes in <5 min
- [ ] Confirm services are healthy on VPS after deploy


Made with [Cursor](https://cursor.com)