### PR TITLE
fix(account): fix UpdateProfileAboutCommand record validation crash

### DIFF
--- a/CoffeePeek.Account.Application/Features/User/UpdateUserProfile/UpdateAbout/UpdateProfileAboutCommand.cs
+++ b/CoffeePeek.Account.Application/Features/User/UpdateUserProfile/UpdateAbout/UpdateProfileAboutCommand.cs
@@ -5,4 +5,4 @@ namespace CoffeePeek.Account.Application.Features.User.UpdateUserProfile.UpdateA
 
 public record UpdateProfileAboutCommand(
     [property: JsonIgnore] Guid UserId,
-    [property: MaxLength(600)] string About);
+    [MaxLength(600)] string About);


### PR DESCRIPTION
## Summary
- Fixes Sentry issue [#130366525](https://sentry.io/issues/130366525): `InvalidOperationException` on `PATCH /api/Users/me/about`
- Moves `[MaxLength(600)]` from `[property: MaxLength(600)]` to the primary constructor parameter so ASP.NET Core model validation accepts it on record types

## Root cause
For C# record types, validation metadata must be on constructor parameters. Using `[property: MaxLength(...)]` applies the attribute to the generated property, which ASP.NET Core 10 rejects with `ThrowIfRecordTypeHasValidationOnProperties()`.

## Test plan
- [x] `dotnet build CoffeePeek.AccountService`
- [x] `dotnet test CoffeePeek.Account.Application.Tests --filter UpdateProfile` (18 passed)
- [ ] After deploy: `PATCH /api/Users/me/about` with valid body returns 202 (not 500)


Made with [Cursor](https://cursor.com)