### PR TITLE
fix(moderation): fix default createdAt/moderatedAt on reviews

### DIFF
--- a/CoffeePeek.Moderation.Application/Mapper/MapsterConfiguration.ModerationReview.cs
+++ b/CoffeePeek.Moderation.Application/Mapper/MapsterConfiguration.ModerationReview.cs
@@ -8,6 +8,8 @@ public partial class MapsterConfiguration
 {
     private static void ConfigureModerationReview(TypeAdapterConfig config)
     {
-        config.NewConfig<ModerationReview, ModerationReviewDto>();
+        config.NewConfig<ModerationReview, ModerationReviewDto>()
+            // DTO uses CreatedAt; entity audit field is CreatedAtUtc
+            .Map(dest => dest.CreatedAt, src => src.CreatedAtUtc);
     }
 }

--- a/CoffeePeek.Moderation.Domain/Aggregates/ModerationReviewAggregate/ModerationReview.cs
+++ b/CoffeePeek.Moderation.Domain/Aggregates/ModerationReviewAggregate/ModerationReview.cs
@@ -17,7 +17,7 @@ public partial class ModerationReview : Entity<Guid>
 
     public string? RejectedReason { get; private set; }
     public Guid? ModeratedBy { get; private set; }
-    public DateTime ModeratedAt { get; private set; }
+    public DateTime? ModeratedAt { get; private set; }
     public ModerationStatus ModerationStatus { get; private set; }
 
     public bool IsSoftDelete { get; private set; }
@@ -45,6 +45,7 @@ public partial class ModerationReview : Entity<Guid>
         Comment = comment;
         Rating = rating;
         ModerationStatus = ModerationStatus.Pending;
+        CreatedAtUtc = DateTime.UtcNow;
         
         if (photos.Count != 0)
         {

--- a/CoffeeShop.Moderation.Persistence/Migrations/20260728193851_MakeModerationReviewModeratedAtNullable.Designer.cs
+++ b/CoffeeShop.Moderation.Persistence/Migrations/20260728193851_MakeModerationReviewModeratedAtNullable.Designer.cs
@@ -3,17 +3,20 @@ using System;
 using CoffeeShop.Moderation.Persistence.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace CoffeePeek.Moderation.Infrastructure.Migrations
+namespace CoffeeShop.Moderation.Persistence.Migrations
 {
     [DbContext(typeof(ModerationDbContext))]
-    partial class ModerationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260728193851_MakeModerationReviewModeratedAtNullable")]
+    partial class MakeModerationReviewModeratedAtNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CoffeeShop.Moderation.Persistence/Migrations/20260728193851_MakeModerationReviewModeratedAtNullable.cs
+++ b/CoffeeShop.Moderation.Persistence/Migrations/20260728193851_MakeModerationReviewModeratedAtNullable.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoffeeShop.Moderation.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeModerationReviewModeratedAtNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ModeratedAt",
+                table: "ModerationReviews",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            // Clear sentinel DateTime.MinValue written for never-moderated reviews
+            migrationBuilder.Sql("""
+                UPDATE "ModerationReviews"
+                SET "ModeratedAt" = NULL
+                WHERE "ModeratedAt" IS NOT NULL
+                  AND "ModeratedAt" < TIMESTAMPTZ '0002-01-01 00:00:00+00';
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ModeratedAt",
+                table: "ModerationReviews",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Pending moderation reviews returned `createdAt` / `moderatedAt` as `0001-01-01T00:00:00`
- **createdAt**: DTO field `CreatedAt` was not mapped from entity `CreatedAtUtc` (AuditInterceptor already persisted the real timestamp)
- **moderatedAt**: non-nullable `DateTime` defaulted to `DateTime.MinValue` until approve/reject; now `DateTime?` + migration clears sentinel values

## Test plan
- [ ] `make up-mod`
- [ ] Create review → GET moderation review: `createdAt` is ~now, `moderatedAt` is `null`
- [ ] Approve → `moderatedAt` is set to UTC now

Made with [Cursor](https://cursor.com)