### PR TITLE
feat(observability): Sentry metrics for popular requests

### DIFF
--- a/CoffeePeek.AccountService/DependencyInjection.cs
+++ b/CoffeePeek.AccountService/DependencyInjection.cs
@@ -1,14 +1,10 @@
-﻿using Asp.Versioning.ApiExplorer;
-using CoffeePeek.Account.Infrastructure.Consumers;
-using CoffeePeek.Account.Persistence.Configuration;
-using CoffeePeek.AccountService.Extensions;
+﻿using CoffeePeek.AccountService.Extensions;
 using CoffeePeek.Shared.Auth.Constants;
 using CoffeePeek.Shared.Auth.Extensions;
-using CoffeePeek.Shared.Kernel.Extentions;
-using CoffeePeek.Shared.Persistence.Extensions;
 using CoffeePeek.Shared.Web;
 using CoffeePeek.Shared.Web.Extensions;
 using CoffeePeek.Shared.Web.Handlers;
+using CoffeePeek.Shared.Web.Sentry;
 
 namespace CoffeePeek.AccountService;
 
@@ -39,7 +35,8 @@ public static class DependencyInjection
     public static IWebHostBuilder ConfigureWebhost(this IWebHostBuilder builder)
     {
         builder.ConfigureEnvironment();
-        builder.UseSentry(options => options.SetBeforeSend(SentryExtensions.FilterExpectedClientErrors));
+        builder.UseCoffeePeekSentry(options =>
+            options.SetBeforeSend(SentryExtensions.FilterExpectedClientErrors));
         return builder;
     }
 }

--- a/CoffeePeek.Gateway/Middleware/GatewayRequestLoggingMiddleware.cs
+++ b/CoffeePeek.Gateway/Middleware/GatewayRequestLoggingMiddleware.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using CoffeePeek.Gateway.Extensions;
 using CoffeePeek.Shared.Web.Logging;
+using CoffeePeek.Shared.Web.Sentry;
 using Yarp.ReverseProxy.Model;
 
 namespace CoffeePeek.Gateway.Middleware;
@@ -12,6 +13,7 @@ namespace CoffeePeek.Gateway.Middleware;
 /// - Matched YARP route ID and cluster ID
 /// - Response status code
 /// - Elapsed time in milliseconds
+/// Also emits Sentry metrics for popular-request tracking.
 /// </summary>
 public class GatewayRequestLoggingMiddleware(RequestDelegate next, ILogger<GatewayRequestLoggingMiddleware> logger)
 {
@@ -45,6 +47,11 @@ public class GatewayRequestLoggingMiddleware(RequestDelegate next, ILogger<Gatew
         var method = context.Request.Method;
         var path = context.Request.Path;
         var elapsed = stopwatch.ElapsedMilliseconds;
+
+        var metricRoute = routeId != "n/a"
+            ? routeId
+            : SentryRequestMetrics.NormalizePath(path.Value ?? "/");
+        SentryRequestMetrics.Record(context, elapsed, metricRoute);
 
         if (statusCode >= 500)
         {

--- a/CoffeePeek.Gateway/Program.cs
+++ b/CoffeePeek.Gateway/Program.cs
@@ -3,6 +3,7 @@ using CoffeePeek.Gateway.Middleware;
 using CoffeePeek.Shared.Web.Extensions;
 using CoffeePeek.Shared.Web.Handlers;
 using CoffeePeek.Shared.Web.Logging;
+using CoffeePeek.Shared.Web.Sentry;
 using CoffePeek.ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -22,6 +23,7 @@ builder.AddServiceDefaults();
 builder.Services.AddServiceDiscovery();
 builder.AddSerilogLogging();
 builder.ConfigureEnvironment();
+builder.WebHost.UseCoffeePeekSentry();
 
 // ── API Documentation ─────────────────────────────────────────────────────────
 builder.Services.AddGatewayOpenApi();

--- a/CoffeePeek.Gateway/appsettings.json
+++ b/CoffeePeek.Gateway/appsettings.json
@@ -8,6 +8,11 @@
     }
   },
   "AllowedHosts": "*",
+  "Sentry": {
+    "Dsn": "",
+    "SendDefaultPii": false,
+    "EnableMetrics": true
+  },
   "JWTOptions": {
     "SecretKey": "",
     "AccessTokenLifetimeMinutes": "",

--- a/CoffeePeek.MediaService/Program.cs
+++ b/CoffeePeek.MediaService/Program.cs
@@ -14,8 +14,10 @@ using CoffeePeek.Shared.Persistence.Data;
 using CoffeePeek.Shared.Persistence.Extensions;
 using CoffeePeek.Shared.Web;
 using CoffeePeek.Shared.Web.Handlers;
+using CoffeePeek.Shared.Web.Sentry;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.UseCoffeePeekSentry();
 var services = builder.Services;
 
 services.AddControllers();

--- a/CoffeePeek.ModerationService/DependencyInjection.cs
+++ b/CoffeePeek.ModerationService/DependencyInjection.cs
@@ -3,6 +3,7 @@ using CoffeePeek.Shared.Auth.Extensions;
 using CoffeePeek.Shared.Web;
 using CoffeePeek.Shared.Web.Extensions;
 using CoffeePeek.Shared.Web.Handlers;
+using CoffeePeek.Shared.Web.Sentry;
 
 namespace CoffeePeek.ModerationService;
 
@@ -37,7 +38,7 @@ public static class DependencyInjection
     public static IWebHostBuilder ConfigureWebhost(this IWebHostBuilder builder)
     {
         builder.ConfigureEnvironment();
-        builder.UseSentry();
+        builder.UseCoffeePeekSentry();
 
         return builder;
     }

--- a/CoffeePeek.Shared.Web/Sentry/SentryHostingExtensions.cs
+++ b/CoffeePeek.Shared.Web/Sentry/SentryHostingExtensions.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using Sentry.AspNetCore;
+
+namespace CoffeePeek.Shared.Web.Sentry;
+
+public static class SentryHostingExtensions
+{
+    /// <summary>
+    /// Configures Sentry with metrics enabled for request popularity tracking.
+    /// </summary>
+    public static IWebHostBuilder UseCoffeePeekSentry(
+        this IWebHostBuilder builder,
+        Action<SentryAspNetCoreOptions>? configure = null)
+    {
+        return builder.UseSentry(options =>
+        {
+            options.EnableMetrics = true;
+            options.SendDefaultPii = false;
+            configure?.Invoke(options);
+        });
+    }
+}

--- a/CoffeePeek.Shared.Web/Sentry/SentryRequestMetrics.cs
+++ b/CoffeePeek.Shared.Web/Sentry/SentryRequestMetrics.cs
@@ -1,0 +1,102 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using CoffeePeek.Shared.Web.Logging;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Sentry;
+
+namespace CoffeePeek.Shared.Web.Sentry;
+
+public static partial class SentryRequestMetrics
+{
+    public const string RequestCounterName = "http.request";
+    public const string RequestDurationName = "http.request.duration";
+
+    /// <summary>
+    /// Records request popularity (count) and latency (distribution) to Sentry Metrics.
+    /// Prefer low-cardinality route templates over raw paths with ids.
+    /// </summary>
+    public static void Record(HttpContext context, long elapsedMs, string? routeOverride = null)
+    {
+        if (!SentrySdk.IsEnabled)
+            return;
+
+        var method = context.Request.Method;
+        var status = context.Response.StatusCode.ToString();
+        var route = routeOverride ?? ResolveRoute(context);
+
+        var tags = new Dictionary<string, object>
+        {
+            ["method"] = method,
+            ["route"] = route,
+            ["status"] = status
+        };
+
+        SentrySdk.Metrics.EmitCounter(RequestCounterName, 1, tags);
+        SentrySdk.Metrics.EmitDistribution(
+            RequestDurationName,
+            elapsedMs,
+            MeasurementUnit.Duration.Millisecond,
+            tags);
+    }
+
+    public static string ResolveRoute(HttpContext context)
+    {
+        if (context.GetEndpoint() is RouteEndpoint routeEndpoint
+            && !string.IsNullOrWhiteSpace(routeEndpoint.RoutePattern.RawText))
+        {
+            return routeEndpoint.RoutePattern.RawText!;
+        }
+
+        return NormalizePath(context.Request.Path.Value ?? "/");
+    }
+
+    public static string NormalizePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return "/";
+
+        var normalized = GuidPathRegex().Replace(path, "/{id}");
+        normalized = NumericSegmentRegex().Replace(normalized, "/{id}");
+        return normalized;
+    }
+
+    [GeneratedRegex(@"/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(?=/|$)", RegexOptions.CultureInvariant)]
+    private static partial Regex GuidPathRegex();
+
+    [GeneratedRegex(@"/\d+(?=/|$)", RegexOptions.CultureInvariant)]
+    private static partial Regex NumericSegmentRegex();
+}
+
+/// <summary>
+/// Emits Sentry metrics for each non-health HTTP request (count + duration).
+/// </summary>
+public sealed class SentryRequestMetricsMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (RequestLoggingExtensions.IsHealthCheckPath(context.Request.Path))
+        {
+            await next(context);
+            return;
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            await next(context);
+        }
+        finally
+        {
+            stopwatch.Stop();
+            SentryRequestMetrics.Record(context, stopwatch.ElapsedMilliseconds);
+        }
+    }
+}
+
+public static class SentryRequestMetricsMiddlewareExtensions
+{
+    public static IApplicationBuilder UseSentryRequestMetrics(this IApplicationBuilder app) =>
+        app.UseMiddleware<SentryRequestMetricsMiddleware>();
+}

--- a/CoffeePeek.ShopsService/DependencyInjection.cs
+++ b/CoffeePeek.ShopsService/DependencyInjection.cs
@@ -3,6 +3,7 @@ using CoffeePeek.Shared.Auth.Extensions;
 using CoffeePeek.Shared.Web;
 using CoffeePeek.Shared.Web.Extensions;
 using CoffeePeek.Shared.Web.Handlers;
+using CoffeePeek.Shared.Web.Sentry;
 
 namespace CoffeePeek.ShopsService;
 
@@ -37,7 +38,7 @@ public static class DependencyInjection
     public static IWebHostBuilder ConfigureWebhost(this IWebHostBuilder builder)
     {
         builder.ConfigureEnvironment();
-        builder.UseSentry();
+        builder.UseCoffeePeekSentry();
 
         return builder;
     }


### PR DESCRIPTION
## Summary
- Enable Sentry metrics (`EnableMetrics`) via shared `UseCoffeePeekSentry()` on Gateway, Account, Shops, Moderation, and Media
- Emit `http.request` (counter) and `http.request.duration` (distribution) from Gateway request middleware
- Tag by YARP `route` / `method` / `status` for low-cardinality popularity charts

## Test plan
- [ ] Deploy with `SENTRY_DSN_GATEWAY` set
- [ ] Hit a few public API routes through the gateway
- [ ] Confirm metrics appear in Sentry → Metrics (`http.request`, group by `route`)
- [ ] Confirm health checks are not counted


Made with [Cursor](https://cursor.com)