### PR TITLE
fix(account): RefreshToken login concurrency (CP-ACCOUNT-SERVICE-2M)

### DIFF
--- a/CoffeePeek.Account.Domain.Tests/RefreshTokenTests.cs
+++ b/CoffeePeek.Account.Domain.Tests/RefreshTokenTests.cs
@@ -22,6 +22,7 @@ public class RefreshTokenTests
         var afterCreation = DateTime.UtcNow;
 
         // Assert
+        refreshToken.Id.Should().NotBe(Guid.Empty);
         refreshToken.UserId.Should().Be(userId);
         refreshToken.Token.Should().Be(token);
         refreshToken.DeviceName.Should().Be(device);

--- a/CoffeePeek.Account.Persistence/Configuration/RefreshTokenConfiguration.cs
+++ b/CoffeePeek.Account.Persistence/Configuration/RefreshTokenConfiguration.cs
@@ -8,6 +8,10 @@ public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
 {
     public void Configure(EntityTypeBuilder<RefreshToken> builder)
     {
+        // Client-generated PK: domain sets Id = Guid.NewGuid() in the ctor.
+        // Without ValueGeneratedNever, EF treats a non-empty Guid as an existing row
+        // and issues UPDATE (0 rows) → DbUpdateConcurrencyException on login/AddSession.
+        builder.Property(rt => rt.Id).ValueGeneratedNever();
         builder.HasIndex(rt => rt.Token);
     }
 }

--- a/CoffeePeek.Account.Persistence/Migrations/AccountDbContextModelSnapshot.cs
+++ b/CoffeePeek.Account.Persistence/Migrations/AccountDbContextModelSnapshot.cs
@@ -63,7 +63,6 @@ namespace CoffeePeek.Account.Persistence.Migrations
             modelBuilder.Entity("CoffeePeek.Account.Domain.Entities.RefreshToken", b =>
                 {
                     b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreatedAtUtc")


### PR DESCRIPTION
## Summary
- `RefreshToken.Id` is client-generated (`Guid.NewGuid()`) for admin session revoke
- EF default `ValueGeneratedOnAdd` treated new tokens as existing → UPDATE 0 rows → `DbUpdateConcurrencyException` on login
- Fix: `ValueGeneratedNever()` on `RefreshToken.Id`

## Test plan
- [ ] Login `POST /api/Tokens` succeeds in prod after deploy
- [ ] Refresh token rotation still works
- [ ] `dotnet test` Account.Domain RefreshToken tests

Refs: Sentry CP-ACCOUNT-SERVICE-2M / 138143181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Исправления**
  - Улучшено создание токенов обновления: каждому новому токену гарантированно присваивается уникальный идентификатор.
  - Повышена надежность операций авторизации и обновления сессии.

- **Тесты**
  - Добавлена проверка корректного присвоения идентификатора при создании токена.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->