### PR TITLE
fix(account): treat RefreshToken Id as client-generated

### DIFF
--- a/CoffeePeek.Account.Domain.Tests/RefreshTokenTests.cs
+++ b/CoffeePeek.Account.Domain.Tests/RefreshTokenTests.cs
@@ -22,6 +22,7 @@ public class RefreshTokenTests
         var afterCreation = DateTime.UtcNow;
 
         // Assert
+        refreshToken.Id.Should().NotBe(Guid.Empty);
         refreshToken.UserId.Should().Be(userId);
         refreshToken.Token.Should().Be(token);
         refreshToken.DeviceName.Should().Be(device);

--- a/CoffeePeek.Account.Persistence/Configuration/RefreshTokenConfiguration.cs
+++ b/CoffeePeek.Account.Persistence/Configuration/RefreshTokenConfiguration.cs
@@ -8,6 +8,10 @@ public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
 {
     public void Configure(EntityTypeBuilder<RefreshToken> builder)
     {
+        // Client-generated PK: domain sets Id = Guid.NewGuid() in the ctor.
+        // Without ValueGeneratedNever, EF treats a non-empty Guid as an existing row
+        // and issues UPDATE (0 rows) → DbUpdateConcurrencyException on login/AddSession.
+        builder.Property(rt => rt.Id).ValueGeneratedNever();
         builder.HasIndex(rt => rt.Token);
     }
 }

--- a/CoffeePeek.Account.Persistence/Migrations/AccountDbContextModelSnapshot.cs
+++ b/CoffeePeek.Account.Persistence/Migrations/AccountDbContextModelSnapshot.cs
@@ -63,7 +63,6 @@ namespace CoffeePeek.Account.Persistence.Migrations
             modelBuilder.Entity("CoffeePeek.Account.Domain.Entities.RefreshToken", b =>
                 {
                     b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreatedAtUtc")


### PR DESCRIPTION
EF was issuing UPDATE for new sessions after Guid.NewGuid() on create, causing DbUpdateConcurrencyException on POST /api/Tokens.