### PR TITLE
Add local dev environment tooling + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md
+
+General architecture, conventions, and build/test/migration commands live in `CLAUDE.md`
+(read it first). This file only adds cloud-agent operating notes.
+
+## Cursor Cloud specific instructions
+
+CoffeePeek is a backend-only .NET 10 microservices platform. Five ASP.NET Core services run
+behind a YARP gateway and talk to Postgres (4 DBs), RabbitMQ (Wolverine bus), Redis, and MinIO.
+There is no in-repo frontend; you interact with the system over HTTP through the gateway.
+
+### What the update script / snapshot already provide
+- .NET 10 SDK at `/usr/share/dotnet` (`dotnet` on `PATH`), `dotnet-ef` global tool, and Docker
+  engine are pre-installed. The startup update script runs `dotnet restore CoffeePeek.Backend.ci.slnf`.
+- Do NOT reinstall these in normal work.
+
+### Running everything (dev mode)
+Helper scripts live in `dev/` (all commands from repo root):
+1. Start the Docker daemon (it does not persist across sessions; systemd is not managing it):
+   `sudo dockerd > /tmp/dockerd.log 2>&1 &` then wait until `docker info` succeeds.
+2. Start backing services: `docker compose -f dev/docker-compose.dev.yml up -d`
+   (Postgres+4 DBs, RabbitMQ, Redis, MinIO+buckets; local-dev credentials in `dev/dev.env`).
+3. Apply migrations + seed roles: `dev/migrate-and-seed.sh`  (idempotent).
+4. Run the five services: `dev/run-services.sh`  (`--no-build` to skip the build).
+   Ports: gateway `8080`, account `5353`, shops `5243`, moderation `6453`, media `5025`.
+   Logs: `dev/logs/<service>.log`. Stop with `dev/stop-services.sh`.
+5. Smoke test end to end: `dev/hello-world.sh` (register → confirm email → login → `/api/Users/me`
+   → `/api/CoffeeShops`, all through the gateway).
+
+### Non-obvious gotchas (important)
+- Config is injected via env vars, not committed appsettings. In `Development` each data service
+  reads its EF connection from `ConnectionStrings__<dbname>` (Aspire Npgsql, names in
+  `CoffeePeek.Shared.Kernel/AppResources.cs`) AND the Wolverine outbox from
+  `PostgresCpOptions__ConnectionString`; both must point at the same DB. `dev/dev.env` +
+  `dev/run-services.sh` set all of this. The design-time EF factory only reads
+  `PostgresCpOptions__ConnectionString`, so migrations need it too.
+- `MediaService` fails to start unless `Sentry__Dsn` is set (empty string disables Sentry).
+- `MediaPublicUrlOptions__PublicEndpoint` is validated as a URL on startup for every service —
+  it must be a valid `http(s)` URL or the host refuses to start.
+- The Account service issues JWTs and the Gateway validates them, so `JWTOptions__SecretKey`
+  (min 32 chars) must be identical for both (see `dev/dev.env`).
+- Registration requires a seeded `Roles` row named `User`; roles are NOT auto-seeded by migrations
+  (`dev/migrate-and-seed.sh` inserts them). Login also requires a confirmed email — grab
+  `EmailConfirmationToken` from `cpaccountdb."Users"` and `PUT /api/Users/me/email-confirmation?token=…`
+  (email delivery via Resend is not configured locally).
+- `MediaService` has no `/health` endpoint, so the gateway's `media-cluster` active health check
+  marks it unhealthy and gateway-proxied `/api/Photos` may be reported down even though the service
+  runs; call media directly on `:5025` if needed.
+- Known pre-existing app bug (not an env issue): `GET /openapi/v1.json` returns 500 (the pinned
+  `Microsoft.OpenApi` 2.0.0), so the gateway Scalar UI at `/scalar/` loads but its endpoint list
+  stays empty. Exercise the API with curl instead.
+- `dev/run-services.sh` launches the built DLLs directly (not `dotnet run`) so PIDs can be stopped
+  cleanly; `dotnet run` leaves an orphaned child holding the port on kill.
+
+### Tests / lint
+- Tests need no infra: `dotnet test CoffeePeek.Backend.ci.slnf -c Debug` (492 tests: Account & Shops
+  domain/application/infrastructure).
+- There is no separate linter; the CI gate is the analyzer warnings from `dotnet build` plus the
+  vulnerability audit `dotnet list CoffeePeek.Backend.ci.slnf package --vulnerable --include-transitive`.

--- a/dev/dev.env
+++ b/dev/dev.env
@@ -1,0 +1,60 @@
+# Shared environment variables for running CoffeePeek services locally in
+# Development against the dev infra (dev/docker-compose.dev.yml).
+#
+# Source this file before running `dotnet ef` or the services:
+#   set -a; source dev/dev.env; set +a
+#
+# NOTE: These are LOCAL DEV values only. Per-service values (the Wolverine
+# outbox connection string, MinIO bucket names, listen ports) are set in
+# dev/run-services.sh, since they differ per service.
+
+# --- ASP.NET Core ---
+export ASPNETCORE_ENVIRONMENT=Development
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+
+# --- PostgreSQL (EF Core DbContexts, resolved by Aspire Npgsql by name) ---
+export ConnectionStrings__cpaccountdb="Host=localhost;Port=5432;Database=cpaccountdb;Username=coffeepeek;Password=coffeepeek;SslMode=Disable"
+export ConnectionStrings__cpshopsdb="Host=localhost;Port=5432;Database=cpshopsdb;Username=coffeepeek;Password=coffeepeek;SslMode=Disable"
+export ConnectionStrings__cpmoderationdb="Host=localhost;Port=5432;Database=cpmoderationdb;Username=coffeepeek;Password=coffeepeek;SslMode=Disable"
+export ConnectionStrings__cpmediadb="Host=localhost;Port=5432;Database=cpmediadb;Username=coffeepeek;Password=coffeepeek;SslMode=Disable"
+
+# --- RabbitMQ (Wolverine message bus) ---
+export RabbitMqOptions__HostName=localhost
+export RabbitMqOptions__Port=5672
+export RabbitMqOptions__Username=guest
+export RabbitMqOptions__Password=guest
+export RabbitMqOptions__VirtualHost=/
+
+# --- Redis (cache) ---
+export RedisOptions__Host=localhost
+export RedisOptions__Port=6379
+export RedisOptions__Password=
+
+# --- JWT (Account issues tokens, Gateway validates them: keys MUST match) ---
+export JWTOptions__SecretKey=3155126F-DD2D-4A4A-A039-18093ED2C3F6
+export JWTOptions__Issuer=CoffeePeek.WEB
+export JWTOptions__Audience=CoffeePeek.API
+export JWTOptions__AccessTokenLifetimeMinutes=60
+export JWTOptions__RefreshTokenLifetimeDays=7
+
+# --- Gateway <-> downstream shared secret (header user-context) ---
+export GatewayAuth__SecretKey=CoffeePeek-Gateway-Internal-Auth-Dev-Secret-Key-2026
+
+# --- Sentry disabled locally (empty DSN). MediaService requires this to be set. ---
+export Sentry__Dsn=
+
+# --- MinIO / S3 (object storage) endpoint + credentials (buckets set per service) ---
+export MinIOOptions__Endpoint=http://localhost:9000
+export MinIOOptions__AccessKey=minioadmin
+export MinIOOptions__SecretKey=minioadmin
+
+# --- Public URLs for stored objects (returned to clients; validated as URL on start) ---
+export MediaPublicUrlOptions__PublicEndpoint=http://localhost:9000
+export MediaPublicUrlOptions__ShopBucketName=coffeepeek.shops
+export MediaPublicUrlOptions__AvatarBucketName=coffeepeek.avatars
+
+# --- External integrations: local dev placeholders (email/OAuth not exercised) ---
+export OAuthGoogleOptions__ClientId=dev-google-client-id
+export OAuthGoogleOptions__ClientSecret=dev-google-client-secret
+export ResendClientOptions__ApiToken=re_dev_placeholder_token

--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -1,0 +1,94 @@
+# Local development infrastructure for CoffeePeek.
+# Starts ONLY the backing services (Postgres, RabbitMQ, Redis, MinIO) that the
+# .NET services expect. The services themselves are run on the host with
+# `dotnet run` (see dev/run-services.sh) so they get hot-reload / dev config.
+#
+# Usage:
+#   docker compose -f dev/docker-compose.dev.yml up -d
+#
+# Credentials here are LOCAL DEV ONLY and are referenced by dev/dev.env.
+
+name: coffeepeek-dev-infra
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: coffeepeek
+      POSTGRES_PASSWORD: coffeepeek
+      POSTGRES_DB: postgres
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+      - ../deploy/postgres/init-databases.sql:/docker-entrypoint-initdb.d/init-databases.sql:ro
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U coffeepeek -d postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  rabbitmq:
+    image: rabbitmq:3.13-management-alpine
+    restart: unless-stopped
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+      RABBITMQ_DEFAULT_VHOST: /
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--maxmemory", "128mb", "--maxmemory-policy", "allkeys-lru"]
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  minio:
+    image: quay.io/minio/minio:latest
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    volumes:
+      - minio_data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  minio-init:
+    image: quay.io/minio/mc:latest
+    depends_on:
+      - minio
+    restart: "no"
+    entrypoint: >
+      /bin/sh -c "
+      until mc alias set local http://minio:9000 minioadmin minioadmin; do sleep 2; done;
+      mc mb --ignore-existing local/coffeepeek.shops;
+      mc mb --ignore-existing local/coffeepeek.avatars;
+      mc anonymous set download local/coffeepeek.shops;
+      mc anonymous set download local/coffeepeek.avatars
+      "
+
+volumes:
+  pg_data:
+  minio_data:

--- a/dev/hello-world.sh
+++ b/dev/hello-world.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# End-to-end smoke test for the CoffeePeek dev environment.
+# Exercises: Gateway (routing + JWT validation) -> Account + Shops -> Postgres.
+# Requires infra + all services running (see dev/README steps in AGENTS.md).
+set -euo pipefail
+
+GW=${GATEWAY_URL:-http://localhost:8080}
+PG_CONTAINER=${PG_CONTAINER:-coffeepeek-dev-infra-postgres-1}
+EMAIL="barista+$(date +%s)@coffeepeek.dev"
+USER="barista$(date +%s | tail -c 6)"
+PASS="CoffeePeek123!"
+
+line() { printf '\n\033[1m== %s ==\033[0m\n' "$1"; }
+
+line "1. Register a new user  (POST $GW/api/Users)"
+curl -sS -X POST "$GW/api/Users" -H 'Content-Type: application/json' \
+  -d "{\"userName\":\"$USER\",\"email\":\"$EMAIL\",\"password\":\"$PASS\"}" -w "\nHTTP %{http_code}\n"
+
+line "2. Confirm email  (token read from DB, simulating the email link)"
+TOKEN=$(docker exec "$PG_CONTAINER" psql -U coffeepeek -d cpaccountdb -t -A \
+  -c "SELECT \"EmailConfirmationToken\" FROM \"Users\" WHERE \"Email\"='$EMAIL';")
+curl -sS -X PUT "$GW/api/Users/me/email-confirmation?token=$TOKEN" -w "\nHTTP %{http_code}\n"
+
+line "3. Log in  (POST $GW/api/Tokens) -> JWT"
+RESP=$(curl -sS -X POST "$GW/api/Tokens" -H 'Content-Type: application/json' \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASS\"}")
+ACCESS=$(echo "$RESP" | python3 -c "import sys,json;print(json.load(sys.stdin)['data']['accessToken'])")
+echo "access token acquired (${#ACCESS} chars)"
+
+line "4. Call authenticated endpoint  (GET $GW/api/Users/me, JWT validated at gateway)"
+curl -sS "$GW/api/Users/me" -H "Authorization: Bearer $ACCESS" -w "\nHTTP %{http_code}\n"
+
+line "5. Query Shops service via gateway  (GET $GW/api/CoffeeShops)"
+curl -sS "$GW/api/CoffeeShops?page=1&pageSize=5" -H "Authorization: Bearer $ACCESS" -w "\nHTTP %{http_code}\n"
+
+line "DONE - environment verified end to end"

--- a/dev/migrate-and-seed.sh
+++ b/dev/migrate-and-seed.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Apply EF Core migrations to the 4 CoffeePeek databases and seed the Roles table.
+# Requires the dev infra to be running (dev/docker-compose.dev.yml) and dotnet-ef installed:
+#   dotnet tool install --global dotnet-ef --version "10.*"
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export DOTNET_ROOT=${DOTNET_ROOT:-/usr/share/dotnet}
+export PATH="$PATH:$DOTNET_ROOT:$HOME/.dotnet/tools"
+
+# shellcheck disable=SC1091
+set -a; source dev/dev.env; set +a
+
+PG_CONTAINER=${PG_CONTAINER:-coffeepeek-dev-infra-postgres-1}
+
+mig() {
+  local db="$1" proj="$2" startup="$3" ctx="$4"
+  echo "== migrate $ctx -> $db =="
+  PostgresCpOptions__ConnectionString="Host=localhost;Port=5432;Database=$db;Username=coffeepeek;Password=coffeepeek;SslMode=Disable" \
+    dotnet ef database update --project "$proj" --startup-project "$startup" --context "$ctx"
+}
+
+mig cpaccountdb    CoffeePeek.Account.Persistence      CoffeePeek.AccountService     AccountDbContext
+mig cpshopsdb      CoffeePeek.Shops.Persistance        CoffeePeek.ShopsService       ShopsDbContext
+mig cpmoderationdb CoffeeShop.Moderation.Persistence   CoffeePeek.ModerationService  ModerationDbContext
+mig cpmediadb      CoffeePeek.MediaService             CoffeePeek.MediaService       MediaDbContext
+
+echo "== seed roles (cpaccountdb) =="
+docker exec "$PG_CONTAINER" psql -U coffeepeek -d cpaccountdb -c \
+  "INSERT INTO \"Roles\" (\"Id\", \"Name\", \"CreatedAtUtc\") \
+   SELECT gen_random_uuid(), r, now() FROM (VALUES ('User'),('Admin'),('Moderator'),('Owner'),('Employee'),('Roaster')) AS t(r) \
+   WHERE NOT EXISTS (SELECT 1 FROM \"Roles\" WHERE \"Name\" = t.r);"
+
+echo "Done."

--- a/dev/run-services.sh
+++ b/dev/run-services.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Run all CoffeePeek services locally in Development against the dev infra.
+#
+# Prereqs:
+#   1. Infra running:   docker compose -f dev/docker-compose.dev.yml up -d
+#   2. DBs migrated:    dev/migrate-and-seed.sh   (migrations + role seed)
+#
+# Usage:
+#   dev/run-services.sh            # build once, then start all 5 services
+#   dev/run-services.sh --no-build # skip build (services already built)
+#
+# Logs go to dev/logs/<service>.log ; PIDs to dev/logs/<service>.pid
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export DOTNET_ROOT=${DOTNET_ROOT:-/usr/share/dotnet}
+export PATH="$PATH:$DOTNET_ROOT:$HOME/.dotnet/tools"
+
+# shellcheck disable=SC1091
+set -a; source dev/dev.env; set +a
+
+LOG_DIR="$ROOT/dev/logs"
+mkdir -p "$LOG_DIR"
+
+BUILD=1
+[[ "${1:-}" == "--no-build" ]] && BUILD=0
+
+pg() { echo "Host=localhost;Port=5432;Database=$1;Username=coffeepeek;Password=coffeepeek;SslMode=Disable"; }
+
+if [[ "$BUILD" == "1" ]]; then
+  echo "Building services (Debug)..."
+  dotnet build CoffeePeek.Backend.ci.slnf -c Debug -m -p:AllowMissingPrunePackageData=true >/dev/null
+fi
+
+# Run the built DLLs directly (not `dotnet run`) so the tracked PID is the actual
+# app process and can be stopped reliably (dotnet run does not forward signals).
+start() {
+  local name="$1" proj="$2"; shift 2
+  local dll="$ROOT/$proj/bin/Debug/net10.0/$proj.dll"
+  if [[ ! -f "$dll" ]]; then echo "Missing $dll — run without --no-build first." >&2; exit 1; fi
+  echo "Starting $name ..."
+  ( cd "$ROOT/$proj" && env "$@" nohup dotnet "$dll" \
+      >"$LOG_DIR/$name.log" 2>&1 & echo $! >"$LOG_DIR/$name.pid" )
+}
+
+start account CoffeePeek.AccountService \
+  ASPNETCORE_URLS=http://localhost:5353 \
+  PostgresCpOptions__ConnectionString="$(pg cpaccountdb)" \
+  MinIOOptions__BucketName=coffeepeek.avatars \
+  AdminStatsOptions__ShopsServiceUrl=http://localhost:5243 \
+  AdminStatsOptions__ModerationServiceUrl=http://localhost:6453
+
+start shops CoffeePeek.ShopsService \
+  ASPNETCORE_URLS=http://localhost:5243 \
+  PostgresCpOptions__ConnectionString="$(pg cpshopsdb)"
+
+start moderation CoffeePeek.ModerationService \
+  ASPNETCORE_URLS=http://localhost:6453 \
+  PostgresCpOptions__ConnectionString="$(pg cpmoderationdb)" \
+  MinIOOptions__BucketName=coffeepeek.shops
+
+start media CoffeePeek.MediaService \
+  ASPNETCORE_URLS=http://localhost:5025 \
+  PostgresCpOptions__ConnectionString="$(pg cpmediadb)" \
+  MinIOOptions__ShopBucketName=coffeepeek.shops \
+  MinIOOptions__UserBucketName=coffeepeek.avatars
+
+start gateway CoffeePeek.Gateway \
+  ASPNETCORE_URLS=http://localhost:8080
+
+echo
+echo "All services launched. Tail logs with: tail -f dev/logs/<service>.log"
+echo "Gateway:     http://localhost:8080  (Scalar docs at /scalar)"
+echo "Account:5353 Shops:5243 Moderation:6453 Media:5025"

--- a/dev/stop-services.sh
+++ b/dev/stop-services.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Stop all CoffeePeek services started by dev/run-services.sh.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="$ROOT/dev/logs"
+for s in account shops moderation media gateway; do
+  pid=$(cat "$LOG_DIR/$s.pid" 2>/dev/null || true)
+  if [[ -n "${pid:-}" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null && echo "stopped $s ($pid)"
+  fi
+  rm -f "$LOG_DIR/$s.pid"
+done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents a reproducible **development** environment for the CoffeePeek .NET 10 microservices platform, and verifies it works end to end through the gateway. No application code was changed — only new dev tooling and docs were added.

### What was set up (on the VM)
- **.NET 10 SDK** (`10.0.100`, per `global.json`) + `dotnet-ef` global tool
- **Docker engine** (for backing services)
- Restored/built `CoffeePeek.Backend.ci.slnf` and ran the full test suite: **492 tests passing**

### New files
- `dev/docker-compose.dev.yml` — local infra: Postgres (+4 DBs), RabbitMQ, Redis, MinIO (+buckets)
- `dev/dev.env` — shared env vars to run the services in `Development` against local infra
- `dev/migrate-and-seed.sh` — applies EF migrations to the 4 DBs and seeds the `Roles` table
- `dev/run-services.sh` / `dev/stop-services.sh` — run/stop the 5 services (built DLLs, reliable PIDs)
- `dev/hello-world.sh` — end-to-end smoke test through the gateway
- `AGENTS.md` — `## Cursor Cloud specific instructions` with the non-obvious run/test gotchas

### How to run (dev mode)
```
sudo dockerd > /tmp/dockerd.log 2>&1 &            # daemon isn't persisted across sessions
docker compose -f dev/docker-compose.dev.yml up -d
dev/migrate-and-seed.sh
dev/run-services.sh
dev/hello-world.sh
```
Gateway on `:8080` (Scalar at `/scalar/`); account `:5353`, shops `:5243`, moderation `:6453`, media `:5025`.

### End-to-end verification (hello-world)
Register → confirm email → login (JWT) → authenticated `GET /api/Users/me` → `GET /api/CoffeeShops`, all through the gateway — every call returns `HTTP 200`. The Wolverine bus provisioned **97 queues** across services, confirming the full stack is connected.

[coffeepeek_running_services_browser_demo.mp4](https://cursor.com/agents/bc-aab49280-7496-4c41-8885-23e1d0b3438c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcoffeepeek_running_services_browser_demo.mp4)

### Notable pre-existing findings (not fixed here — no code changes)
- `GET /openapi/v1.json` returns 500 (pinned `Microsoft.OpenApi` 2.0.0), so the Scalar UI loads but its endpoint list stays empty; use curl.
- `MediaService` has no `/health` endpoint, so the gateway marks `media-cluster` unhealthy even though media runs.
- Roles are not auto-seeded and login requires a confirmed email — handled by `dev/migrate-and-seed.sh` and documented in `AGENTS.md`.

### Notes
- The startup update script is minimal: `dotnet restore CoffeePeek.Backend.ci.slnf`. Service/infra startup lives in `dev/` scripts + `AGENTS.md`, not the update script.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aab49280-7496-4c41-8885-23e1d0b3438c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aab49280-7496-4c41-8885-23e1d0b3438c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

