### PR TITLE
Dev

### DIFF
--- a/CoffeePeek.Moderation.Application/Features/Admin/Stats/GetAdminModerationStatsHandler.cs
+++ b/CoffeePeek.Moderation.Application/Features/Admin/Stats/GetAdminModerationStatsHandler.cs
@@ -13,12 +13,10 @@ public static class GetAdminModerationStatsHandler
         IShopImportCandidateRepository importRepository,
         CancellationToken ct)
     {
-        var pendingTask = repository.GetStatsAsync(ct);
-        var importTask = importRepository.GetStatsAsync(ct);
-        await Task.WhenAll(pendingTask, importTask);
-
-        var (pendingShops, pendingReviews) = await pendingTask;
-        var import = await importTask;
+        // Sequential: both repositories share the same scoped ModerationDbContext.
+        // Parallel Task.WhenAll causes InvalidOperationException (concurrent DbContext use).
+        var (pendingShops, pendingReviews) = await repository.GetStatsAsync(ct);
+        var import = await importRepository.GetStatsAsync(ct);
 
         return Response<AdminServiceStatsDto>.Success(new AdminServiceStatsDto(
             PendingModerationShops: pendingShops,


### PR DESCRIPTION
## Summary
- Fix Moderation `GET /api/admin/stats/summary` 500 caused by parallel EF queries on the same scoped `DbContext`.
- Admin overview (`GET /api/admin/stats/overview`) no longer fails when Account calls Moderation for pending/import counts.

## Test plan
- [ ] Open admin dashboard stats overview after deploy
- [ ] Confirm Moderation `/api/admin/stats/summary` returns 200
- [ ] Confirm Sentry CP-ACCOUNT-SERVICE-2N / CP-MODERARION-SERVICE-Z stop firing


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Улучшена стабильность формирования статистики модерации за счёт последовательной обработки данных из нескольких источников.
  * Результаты статистики остаются доступными в прежнем виде.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->