### PR TITLE
fix(account): stop Google login 500 on email lookup and missing OAuth…

### DIFF
--- a/CoffeePeek.Account.Infrastructure.Tests/Identity/GoogleAuthServiceTests.cs
+++ b/CoffeePeek.Account.Infrastructure.Tests/Identity/GoogleAuthServiceTests.cs
@@ -1,0 +1,41 @@
+using CoffeePeek.Account.Infrastructure.Identity;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CoffeePeek.Account.Infrastructure.Tests.Identity;
+
+public class GoogleAuthServiceTests
+{
+    private static GoogleAuthService CreateSut(string clientId, string clientSecret = "")
+    {
+        var options = Microsoft.Extensions.Options.Options.Create(new OAuthGoogleOptions
+        {
+            ClientId = clientId,
+            ClientSecret = clientSecret
+        });
+        return new GoogleAuthService(options, NullLogger<GoogleAuthService>.Instance);
+    }
+
+    [Fact]
+    public void Constructor_WhenClientSecretMissing_DoesNotThrow()
+    {
+        var act = () => CreateSut("client-id.apps.googleusercontent.com");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task ValidateIdTokenAsync_WhenClientIdMissing_ReturnsNull()
+    {
+        var sut = CreateSut("");
+        var result = await sut.ValidateIdTokenAsync("test", TestContext.Current.CancellationToken);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ValidateIdTokenAsync_WhenTokenIsGarbage_ReturnsNull()
+    {
+        var sut = CreateSut("770099870632-5eeebr3eqdrma4reson9mv02j4lro583.apps.googleusercontent.com");
+        var result = await sut.ValidateIdTokenAsync("test", TestContext.Current.CancellationToken);
+        result.Should().BeNull();
+    }
+}

--- a/CoffeePeek.Account.Infrastructure/CoffeePeek.Account.Infrastructure.csproj
+++ b/CoffeePeek.Account.Infrastructure/CoffeePeek.Account.Infrastructure.csproj
@@ -7,6 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Google.Apis.Auth" />
+    </ItemGroup>
+
+    <ItemGroup>
       <ProjectReference Include="..\CoffeePeek.Account.Application\CoffeePeek.Account.Application.csproj" />
     </ItemGroup>
 

--- a/CoffeePeek.Account.Infrastructure/DependencyInjection.cs
+++ b/CoffeePeek.Account.Infrastructure/DependencyInjection.cs
@@ -44,7 +44,8 @@ public static class DependencyInjection
         services.AddTransient<IResend, ResendClient>();
 
         // 4. OAuth
-        services.AddValidateOptions<OAuthGoogleOptions>();
+        services.AddOptions<OAuthGoogleOptions>()
+            .BindConfiguration(nameof(OAuthGoogleOptions));
         services.AddScoped<IGoogleAuthService, GoogleAuthService>();
 
         services.AddOptions<AdminStatsOptions>()

--- a/CoffeePeek.Account.Infrastructure/OAuthGoogleOptions.cs
+++ b/CoffeePeek.Account.Infrastructure/OAuthGoogleOptions.cs
@@ -1,12 +1,8 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace CoffeePeek.Account.Infrastructure;
 
 public class OAuthGoogleOptions
 {
-    [Required(AllowEmptyStrings = false)]
     public string ClientId { get; set; } = string.Empty;
 
-    [Required(AllowEmptyStrings = false)]
     public string ClientSecret { get; set; } = string.Empty;
 }

--- a/CoffeePeek.Account.Persistence/Repositories/QueryUserRepository.cs
+++ b/CoffeePeek.Account.Persistence/Repositories/QueryUserRepository.cs
@@ -21,8 +21,9 @@ public class QueryUserRepository(AccountDbContext dbContext) : IQueryUserReposit
     public Task<User?> GetByProvider(string provider, string providerId, CancellationToken ct)
     {
         return _repository
-            .AsNoTracking()
             .Include(x => x.Credentials)
+            .Include(x => x.Roles)
+            .Include(x => x.RefreshTokens)
             .FirstOrDefaultAsync(x => x.Credentials.OAuthProvider == provider && x.Credentials.ProviderId == providerId, cancellationToken: ct);
     }
 
@@ -31,7 +32,7 @@ public class QueryUserRepository(AccountDbContext dbContext) : IQueryUserReposit
         return _repository
             .AsNoTracking()
             .Include(x => x.Credentials)
-            .FirstOrDefaultAsync(x => x.Credentials.Email.Value == email, cancellationToken: ct);
+            .FirstOrDefaultAsync(x => x.Credentials.Email == email, cancellationToken: ct);
     }
 
     public async Task<bool> IsEmailUnique(string email, CancellationToken ct)

--- a/CoffeePeek.AccountService/appsettings.json
+++ b/CoffeePeek.AccountService/appsettings.json
@@ -47,6 +47,10 @@
   "ResendClientOptions": {
     "ApiToken": ""
   },
+  "OAuthGoogleOptions": {
+    "ClientId": "770099870632-5eeebr3eqdrma4reson9mv02j4lro583.apps.googleusercontent.com",
+    "ClientSecret": ""
+  },
   "WebClientUrl": "",
   "AdminStatsOptions": {
     "ShopsServiceUrl": "http://shops",

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -34,6 +34,11 @@ JWT_SECRET_KEY=change-me-at-least-32-characters-long-secret
 JWT_ACCESS_TOKEN_MINUTES=60
 JWT_REFRESH_TOKEN_DAYS=30
 
+# Google Sign-In — must match frontend VITE_GOOGLE_CLIENT_ID (full client id, including .apps.googleusercontent.com).
+# ID-token login only needs ClientId; ClientSecret is optional.
+GOOGLE_CLIENT_ID=770099870632-5eeebr3eqdrma4reson9mv02j4lro583.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=
+
 # External services
 RESEND_API_TOKEN=
 WEB_CLIENT_URL=https://coffeepeek.by

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -158,8 +158,8 @@ services:
       MinIOOptions__AccessKey: ${MINIO_ROOT_USER}
       MinIOOptions__SecretKey: ${MINIO_ROOT_PASSWORD}
       MinIOOptions__BucketName: coffeepeek.avatars
-      OAuthGoogleOptions__ClientId: ${GOOGLE_CLIENT_ID}
-      OAuthGoogleOptions__ClientSecret: ${GOOGLE_CLIENT_SECRET}
+      OAuthGoogleOptions__ClientId: ${GOOGLE_CLIENT_ID:-770099870632-5eeebr3eqdrma4reson9mv02j4lro583.apps.googleusercontent.com}
+      OAuthGoogleOptions__ClientSecret: ${GOOGLE_CLIENT_SECRET:-}
       ResendClientOptions__ApiToken: ${RESEND_API_TOKEN}
       WebClientUrl: ${WEB_CLIENT_URL}
       AdminStatsOptions__ShopsServiceUrl: http://shops


### PR DESCRIPTION
… config

EF cannot translate Credentials.Email.Value on the converted Email VO, which crashed GetOrCreate after a valid Google token. Also stop requiring ClientSecret and default the public Web Client ID so empty VPS env no longer fails options validation.