### PR TITLE
Dev

### DIFF
--- a/CoffeePeek.Account.Application.Tests/Features/Admin/Stats/GetAdminOverviewStatsHandlerTests.cs
+++ b/CoffeePeek.Account.Application.Tests/Features/Admin/Stats/GetAdminOverviewStatsHandlerTests.cs
@@ -36,6 +36,7 @@ public class GetAdminOverviewStatsHandlerTests
             ImportPublished: 0,
             ImportRejected: 0,
             ImportSkipped: 0,
+            ImportInFeed: 0,
             ShopsAvailable: false,
             ModerationAvailable: false));
 
@@ -72,6 +73,7 @@ public class GetAdminOverviewStatsHandlerTests
             ImportPublished: 8,
             ImportRejected: 4,
             ImportSkipped: 1,
+            ImportInFeed: 5,
             ShopsAvailable: true,
             ModerationAvailable: true));
 
@@ -86,7 +88,7 @@ public class GetAdminOverviewStatsHandlerTests
         response.Data.PendingModerationReviews.Should().Be(5);
         response.Data.Import.Pending.Should().Be(120);
         response.Data.Import.Published.Should().Be(8);
-        response.Data.Import.InFeed.Should().Be(8);
+        response.Data.Import.InFeed.Should().Be(5);
         response.Data.ShopsAvailable.Should().BeTrue();
         response.Data.ModerationAvailable.Should().BeTrue();
     }

--- a/CoffeePeek.Account.Application/Features/Admin/Stats/GetAdminOverviewStatsHandler.cs
+++ b/CoffeePeek.Account.Application/Features/Admin/Stats/GetAdminOverviewStatsHandler.cs
@@ -31,7 +31,7 @@ public static class GetAdminOverviewStatsHandler
                 platform.ImportPublished,
                 platform.ImportRejected,
                 platform.ImportSkipped,
-                platform.ImportPublished),
+                platform.ImportInFeed),
             ShopsAvailable: platform.ShopsAvailable,
             ModerationAvailable: platform.ModerationAvailable));
     }

--- a/CoffeePeek.Account.Application/Features/Admin/Stats/IAdminStatsClient.cs
+++ b/CoffeePeek.Account.Application/Features/Admin/Stats/IAdminStatsClient.cs
@@ -16,5 +16,6 @@ public sealed record AdminPlatformStatsSnapshot(
     int ImportPublished,
     int ImportRejected,
     int ImportSkipped,
+    int ImportInFeed,
     bool ShopsAvailable,
     bool ModerationAvailable);

--- a/CoffeePeek.Account.Infrastructure.Tests/Consumers/ModerationShopApprovedAccountHandlerTests.cs
+++ b/CoffeePeek.Account.Infrastructure.Tests/Consumers/ModerationShopApprovedAccountHandlerTests.cs
@@ -1,0 +1,42 @@
+using CoffeePeek.Account.Domain.Entities.RoleAggregate;
+using CoffeePeek.Account.Domain.Entities.UserAggregate;
+using CoffeePeek.Account.Infrastructure.Consumers;
+using CoffeePeek.Contract.Dtos.CoffeeShop;
+using CoffeePeek.Contract.Events.Moderation;
+using CoffeePeek.Shared.Kernel;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace CoffeePeek.Account.Infrastructure.Tests.Consumers;
+
+public class ModerationShopApprovedAccountHandlerTests
+{
+    [Fact]
+    public async Task Handle_PassesCancellationTokenToGetByIdAndSaveChanges()
+    {
+        var userRepo = new Mock<IUserRepository>();
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var logger = new Mock<ILogger<ModerationShopApprovedAccountHandler>>();
+        using var cts = new CancellationTokenSource();
+        var ct = cts.Token;
+
+        var user = User.Register("user@example.com", "testuser", "hash", Role.Create("User"));
+        userRepo.Setup(r => r.GetById(user.Id, ct)).ReturnsAsync(user);
+        unitOfWork.Setup(u => u.SaveChangesAsync(ct)).ReturnsAsync(1);
+
+        var sut = new ModerationShopApprovedAccountHandler(userRepo.Object, unitOfWork.Object, logger.Object);
+        var message = new ModerationShopApprovedEvent(user.Id, new ShopDto
+        {
+            Name = "Cafe",
+            Photos = [],
+            Reviews = []
+        });
+
+        await sut.Handle(message, ct);
+
+        user.Statistics.AddedShopsCount.Should().Be(1);
+        userRepo.Verify(r => r.GetById(user.Id, ct), Times.Once);
+        unitOfWork.Verify(u => u.SaveChangesAsync(ct), Times.Once);
+    }
+}

--- a/CoffeePeek.Account.Infrastructure/Admin/AdminStatsClient.cs
+++ b/CoffeePeek.Account.Infrastructure/Admin/AdminStatsClient.cs
@@ -47,6 +47,7 @@ public class AdminStatsClient(
             ImportPublished: moderation?.ImportPublished ?? 0,
             ImportRejected: moderation?.ImportRejected ?? 0,
             ImportSkipped: moderation?.ImportSkipped ?? 0,
+            ImportInFeed: moderation?.ImportInFeed ?? 0,
             ShopsAvailable: shops is not null,
             ModerationAvailable: moderation is not null);
     }

--- a/CoffeePeek.Account.Infrastructure/Consumers/ModerationShopApprovedAccountHandler.cs
+++ b/CoffeePeek.Account.Infrastructure/Consumers/ModerationShopApprovedAccountHandler.cs
@@ -10,11 +10,11 @@ public class ModerationShopApprovedAccountHandler(
     IUnitOfWork unitOfWork,
     ILogger<ModerationShopApprovedAccountHandler> logger)
 {
-    public async Task Handle(ModerationShopApprovedEvent message)
+    public async Task Handle(ModerationShopApprovedEvent message, CancellationToken ct)
     {
         logger.LogInformation("Received ModerationShopApprovedEvent for UserId: {UserId}", message.UserId);
 
-        var user = await userRepository.GetById(message.UserId)
+        var user = await userRepository.GetById(message.UserId, ct)
                    ?? throw new InvalidOperationException("User not found");
 
         user.Statistics.IncrementAddedShops();
@@ -22,6 +22,6 @@ public class ModerationShopApprovedAccountHandler(
         logger.LogInformation("Updated UserStatistics for UserId: {UserId}. New AddedShopsCount: {AddedShopsCount}",
             message.UserId, user.Statistics.AddedShopsCount);
 
-        await unitOfWork.SaveChangesAsync();
+        await unitOfWork.SaveChangesAsync(ct);
     }
 }

--- a/CoffeePeek.Contract/Dtos/Admin/AdminServiceStatsDto.cs
+++ b/CoffeePeek.Contract/Dtos/Admin/AdminServiceStatsDto.cs
@@ -10,4 +10,5 @@ public record AdminServiceStatsDto(
     int ImportPending = 0,
     int ImportPublished = 0,
     int ImportRejected = 0,
-    int ImportSkipped = 0);
+    int ImportSkipped = 0,
+    int ImportInFeed = 0);

--- a/CoffeePeek.Contract/Dtos/Import/ApplyImportDecisionsResultDto.cs
+++ b/CoffeePeek.Contract/Dtos/Import/ApplyImportDecisionsResultDto.cs
@@ -6,4 +6,5 @@ public record ApplyImportDecisionsResultDto(
     int Rejected,
     int Skipped,
     int Unknown,
-    int Missing);
+    int Missing,
+    int Failed = 0);

--- a/CoffeePeek.Moderation.Application/Features/Admin/Stats/GetAdminModerationStatsHandler.cs
+++ b/CoffeePeek.Moderation.Application/Features/Admin/Stats/GetAdminModerationStatsHandler.cs
@@ -24,6 +24,7 @@ public static class GetAdminModerationStatsHandler
             ImportPending: import.Pending,
             ImportPublished: import.Published,
             ImportRejected: import.Rejected,
-            ImportSkipped: import.Skipped));
+            ImportSkipped: import.Skipped,
+            ImportInFeed: import.InFeed));
     }
 }

--- a/CoffeePeek.Moderation.Application/Features/Import/ApplyImportDecisions/ApplyImportDecisionsHandler.cs
+++ b/CoffeePeek.Moderation.Application/Features/Import/ApplyImportDecisions/ApplyImportDecisionsHandler.cs
@@ -40,6 +40,7 @@ public static class ApplyImportDecisionsHandler
         var skipped = 0;
         var unknown = 0;
         var missing = 0;
+        var failed = 0;
         var publishItems = new List<ImportCandidatePublishedItem>();
 
         foreach (var (externalId, raw) in decisions)
@@ -70,7 +71,7 @@ public static class ApplyImportDecisionsHandler
             }
             catch (DomainException)
             {
-                unknown++;
+                failed++;
                 continue;
             }
 
@@ -98,7 +99,7 @@ public static class ApplyImportDecisionsHandler
             : new ImportCandidatePublishedEvent(publishItems);
 
         return (Response<ApplyImportDecisionsResultDto>.Success(
-            new ApplyImportDecisionsResultDto(applied, published, rejected, skipped, unknown, missing)), outbound);
+            new ApplyImportDecisionsResultDto(applied, published, rejected, skipped, unknown, missing, failed)), outbound);
     }
 
     private static Dictionary<string, string> ExtractDecisions(ApplyImportDecisionsCommand command)

--- a/CoffeePeek.Moderation.Application/Features/Import/DecideImportCandidate/DecideImportCandidateHandler.cs
+++ b/CoffeePeek.Moderation.Application/Features/Import/DecideImportCandidate/DecideImportCandidateHandler.cs
@@ -53,7 +53,9 @@ public static class DecideImportCandidateHandler
         await unitOfWork.SaveChangesAsync(ct);
 
         object? outbound = null;
-        if (command.Status == ContractStatus.Published && candidate.CoffeeFocus.HasValue)
+        if (command.Status == ContractStatus.Published
+            && candidate.CoffeeFocus.HasValue
+            && candidate.ResultingShopId is null)
         {
             outbound = new ImportCandidatePublishedEvent(
             [

--- a/CoffeePeek.Moderation.Application/Features/Import/GetImportStats/GetImportStatsHandler.cs
+++ b/CoffeePeek.Moderation.Application/Features/Import/GetImportStats/GetImportStatsHandler.cs
@@ -19,7 +19,7 @@ public static class GetImportStatsHandler
             stats.Skipped,
             stats.Published,
             stats.Rejected,
-            stats.Published,
+            stats.InFeed,
             stats.ByFocus.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value),
             stats.ByBucket.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value),
             new ImportRejectedByReasonDto(

--- a/CoffeePeek.Moderation.Application/Features/Review/SendReviewToModeration/SendReviewToModerationHandler.cs
+++ b/CoffeePeek.Moderation.Application/Features/Review/SendReviewToModeration/SendReviewToModerationHandler.cs
@@ -24,9 +24,7 @@ public static class SendReviewToModerationHandler
             throw new ValidationException(validationResult.ErrorMessage!);
 
         var moderationShop = await moderationShopRepository.GetByPublishedShopId(command.ShopId, ct);
-
-        if (moderationShop == null)
-            throw new NotFoundException("Coffee shop not found");
+        Guid? moderationShopId = moderationShop?.Id;
 
         var photos = new List<PhotoMetadata>();
         if (command.Photos != null && command.Photos.Count != 0)
@@ -38,14 +36,14 @@ public static class SendReviewToModerationHandler
                     x.StorageKey, 
                     x.Size, 
                     command.UserId, 
-                    moderationShop.Id))
+                    moderationShopId))
                 .ToList();
         }
 
         var review = ModerationReview.Create(
             command.UserId,
             command.ShopId,
-            moderationShop.Id,
+            moderationShopId,
             command.UserName,
             command.Header,
             command.Comment,

--- a/CoffeePeek.Moderation.Application/Features/Review/UpdateCoffeeShopReview/UpdateCoffeeShopReviewHandler.cs
+++ b/CoffeePeek.Moderation.Application/Features/Review/UpdateCoffeeShopReview/UpdateCoffeeShopReviewHandler.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using CoffeePeek.Moderation.Domain.Aggregates.ModerationReviewAggregate;
 using CoffeePeek.Shared.Kernel;
+using CoffeePeek.Shared.Kernel.Exceptions;
 using CoffeePeek.Shared.Kernel.Response;
+using CoffeePeek.Shared.Validation;
 
 namespace CoffeePeek.Moderation.Application.Features.Review.UpdateCoffeeShopReview;
 
@@ -9,10 +11,15 @@ public static class UpdateCoffeeShopReviewHandler
 {
     public static async Task<Response<UpdateCoffeeShopReviewResponse>> Handle(
         UpdateCoffeeShopReviewCommand command,
+        IValidationStrategy<UpdateCoffeeShopReviewCommand> validationStrategy,
         IModerationReviewRepository reviewRepository,
         IUnitOfWork unitOfWork,
         CancellationToken ct)
     {
+        var validationResult = validationStrategy.Validate(command);
+        if (!validationResult.IsValid)
+            throw new ValidationException(validationResult.ErrorMessage!);
+
         var review = await reviewRepository.GetById(command.ReviewId, ct);
 
         if (review == null)

--- a/CoffeePeek.Moderation.Application/Features/Shop/UpdateModerationShopStatus/UpdateModerationCoffeeShopStatusHandler.cs
+++ b/CoffeePeek.Moderation.Application/Features/Shop/UpdateModerationShopStatus/UpdateModerationCoffeeShopStatusHandler.cs
@@ -22,7 +22,7 @@ public static class UpdateModerationCoffeeShopStatusHandler
         var shop = await repository.GetByIdAsync(command.Id, ct);
 
         if (shop == null)
-            return (Response.Error("CoffeeShop not found"), null);
+            return (Response.Error(404, "CoffeeShop not found"), null);
 
         object? outboundEvent = null;
         string? auditComment = null;
@@ -30,12 +30,14 @@ public static class UpdateModerationCoffeeShopStatusHandler
 
         if (command.ModerationStatus == ModerationStatus.Approved)
         {
-            shop.Approve();
-            auditAction = ModerationAuditAction.Approved;
-            
-            outboundEvent = new ModerationShopApprovedEvent(
-                shop.UserId,
-                mapper.Map<ShopDto>(shop));
+            // Re-approve is a no-op: skip event + audit so consumers stay idempotent.
+            if (shop.Approve())
+            {
+                auditAction = ModerationAuditAction.Approved;
+                outboundEvent = new ModerationShopApprovedEvent(
+                    shop.UserId,
+                    mapper.Map<ShopDto>(shop));
+            }
         }
         else if (command.ModerationStatus == ModerationStatus.Rejected)
         {
@@ -45,6 +47,10 @@ public static class UpdateModerationCoffeeShopStatusHandler
             shop.Reject(rejectReason);
             auditAction = ModerationAuditAction.Rejected;
             auditComment = rejectReason;
+        }
+        else
+        {
+            return (Response.Error(400, "Moderation status can only be set to Approved or Rejected"), null);
         }
 
         if (auditAction.HasValue)

--- a/CoffeePeek.Moderation.Domain.Tests/Aggregates/ModerationShopApproveTests.cs
+++ b/CoffeePeek.Moderation.Domain.Tests/Aggregates/ModerationShopApproveTests.cs
@@ -1,0 +1,62 @@
+using CoffeePeek.Moderation.Domain.Aggregates;
+using CoffeePeek.Moderation.Domain.Common.Enums;
+using CoffeePeek.Shared.Kernel.Exceptions;
+using FluentAssertions;
+
+namespace CoffeePeek.Moderation.Domain.Tests.Aggregates;
+
+public class ModerationShopApproveTests
+{
+    private static ModerationShop CreatePendingShop() =>
+        ModerationShop.Create("Test Cafe", Guid.NewGuid(), Guid.NewGuid(), description: null);
+
+    [Fact]
+    public void Approve_WhenLocationIsNull_ThrowsDomainException()
+    {
+        var shop = CreatePendingShop();
+
+        var act = () => shop.Approve();
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("Cannot approve shop with unvalidated address.");
+        shop.ModerationStatus.Should().Be(ModerationStatus.Pending);
+    }
+
+    [Fact]
+    public void Approve_WhenLocationIsNotValidated_ThrowsDomainException()
+    {
+        var shop = CreatePendingShop();
+        shop.SetLocation(new ModerationLocation("Unvalidated street"));
+
+        var act = () => shop.Approve();
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("Cannot approve shop with unvalidated address.");
+        shop.ModerationStatus.Should().Be(ModerationStatus.Pending);
+    }
+
+    [Fact]
+    public void Approve_WhenLocationIsValidated_ReturnsTrueAndSetsApproved()
+    {
+        var shop = CreatePendingShop();
+        shop.SetLocation(new ModerationLocation("Validated street", 53.9m, 27.5m));
+
+        var changed = shop.Approve();
+
+        changed.Should().BeTrue();
+        shop.ModerationStatus.Should().Be(ModerationStatus.Approved);
+    }
+
+    [Fact]
+    public void Approve_WhenAlreadyApproved_ReturnsFalseWithoutThrowing()
+    {
+        var shop = CreatePendingShop();
+        shop.SetLocation(new ModerationLocation("Validated street", 53.9m, 27.5m));
+        shop.Approve();
+
+        var changed = shop.Approve();
+
+        changed.Should().BeFalse();
+        shop.ModerationStatus.Should().Be(ModerationStatus.Approved);
+    }
+}

--- a/CoffeePeek.Moderation.Domain.Tests/Aggregates/RatingTests.cs
+++ b/CoffeePeek.Moderation.Domain.Tests/Aggregates/RatingTests.cs
@@ -1,0 +1,37 @@
+using CoffeePeek.Moderation.Domain.Aggregates.ModerationReviewAggregate;
+using CoffeePeek.Shared.Kernel.Exceptions;
+using FluentAssertions;
+
+namespace CoffeePeek.Moderation.Domain.Tests.Aggregates;
+
+public class RatingTests
+{
+    [Theory]
+    [InlineData(0, 3, 3)]
+    [InlineData(6, 3, 3)]
+    [InlineData(3, 0, 3)]
+    [InlineData(3, 6, 3)]
+    [InlineData(3, 3, 0)]
+    [InlineData(3, 3, 6)]
+    public void UpdateRating_OutOfRange_ThrowsDomainException(int place, int service, int coffee)
+    {
+        var rating = Rating.Create(3, 3, 3);
+
+        var act = () => rating.UpdateRating(place, service, coffee);
+
+        act.Should().Throw<DomainException>();
+    }
+
+    [Fact]
+    public void UpdateRating_InRange_UpdatesPlaceServiceCoffeeAndAverage()
+    {
+        var rating = Rating.Create(1, 1, 1);
+
+        rating.UpdateRating(3, 4, 5);
+
+        rating.Place.Should().Be(3);
+        rating.Service.Should().Be(4);
+        rating.Coffee.Should().Be(5);
+        rating.AverageRating.Should().Be((3m + 4m + 5m) / 3m);
+    }
+}

--- a/CoffeePeek.Moderation.Domain.Tests/Aggregates/ShopImportCandidateTests.cs
+++ b/CoffeePeek.Moderation.Domain.Tests/Aggregates/ShopImportCandidateTests.cs
@@ -141,6 +141,33 @@ public class ShopImportCandidateTests
     }
 
     [Fact]
+    public void Decide_AlreadyPublishedToCatalog_Throws()
+    {
+        var candidate = ShopImportCandidate.FromOsm(Snapshot("node/1", "Varka"), Now);
+        candidate.Decide(ImportQueueStatus.Published, ImportCoffeeFocus.Cafe, [], Reviewer, false, Now);
+        candidate.AttachPublishedShop(Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"));
+
+        var act = () => candidate.Decide(
+            ImportQueueStatus.Published, ImportCoffeeFocus.Cafe, [], Reviewer, false, Now);
+
+        act.Should().Throw<DomainException>().WithMessage("Candidate is already published to the catalog.");
+    }
+
+    [Fact]
+    public void Decide_StuckPublishedWithoutShopId_AllowsRetry()
+    {
+        var candidate = ShopImportCandidate.FromOsm(Snapshot("node/1", "Varka"), Now);
+        candidate.Decide(ImportQueueStatus.Published, ImportCoffeeFocus.Cafe, [], Reviewer, false, Now);
+        candidate.ResultingShopId.Should().BeNull();
+
+        candidate.Decide(ImportQueueStatus.Published, ImportCoffeeFocus.Specialty, ["to_go"], Reviewer, false, Now);
+
+        candidate.QueueStatus.Should().Be(ImportQueueStatus.Published);
+        candidate.CoffeeFocus.Should().Be(ImportCoffeeFocus.Specialty);
+        candidate.ResultingShopId.Should().BeNull();
+    }
+
+    [Fact]
     public void RefreshFromOsm_DoesNotResurrectRejected()
     {
         var candidate = ShopImportCandidate.FromOsm(Snapshot("node/1", "Varka"), Now);
@@ -152,6 +179,42 @@ public class ShopImportCandidateTests
         candidate.QueueStatus.Should().Be(ImportQueueStatus.Rejected);
         candidate.RejectReason.Should().Be(ImportRejectReason.Invalid);
         candidate.Name.Should().Be("Varka Coffee");
+    }
+
+    [Fact]
+    public void RefreshFromOsm_DoesNotOverwritePublishedName()
+    {
+        var candidate = ShopImportCandidate.FromOsm(Snapshot("node/1", "Varka"), Now);
+        candidate.Decide(ImportQueueStatus.Published, ImportCoffeeFocus.Cafe, [], Reviewer, false, Now);
+        var address = candidate.Address;
+        var latitude = candidate.Latitude;
+        var longitude = candidate.Longitude;
+
+        candidate.RefreshFromOsm(Snapshot("node/1", "Varka Coffee"), Now.AddDays(1));
+
+        candidate.Name.Should().Be("Varka");
+        candidate.Address.Should().Be(address);
+        candidate.Latitude.Should().Be(latitude);
+        candidate.Longitude.Should().Be(longitude);
+        candidate.QueueStatus.Should().Be(ImportQueueStatus.Published);
+    }
+
+    [Fact]
+    public void RefreshFromOsm_DoesNotOverwriteSkippedName()
+    {
+        var candidate = ShopImportCandidate.FromOsm(Snapshot("node/1", "Varka"), Now);
+        candidate.Decide(ImportQueueStatus.Skipped, null, [], Reviewer, false, Now);
+        var address = candidate.Address;
+        var latitude = candidate.Latitude;
+        var longitude = candidate.Longitude;
+
+        candidate.RefreshFromOsm(Snapshot("node/1", "Varka Coffee"), Now.AddDays(1));
+
+        candidate.Name.Should().Be("Varka");
+        candidate.Address.Should().Be(address);
+        candidate.Latitude.Should().Be(latitude);
+        candidate.Longitude.Should().Be(longitude);
+        candidate.QueueStatus.Should().Be(ImportQueueStatus.Skipped);
     }
 
     [Fact]

--- a/CoffeePeek.Moderation.Domain.Tests/ModerationReviewTests.cs
+++ b/CoffeePeek.Moderation.Domain.Tests/ModerationReviewTests.cs
@@ -1,0 +1,95 @@
+using CoffeePeek.Moderation.Domain.Aggregates.ModerationReviewAggregate;
+using CoffeePeek.Moderation.Domain.Entities;
+using CoffeePeek.Shared.Kernel.Exceptions;
+using FluentAssertions;
+
+namespace CoffeePeek.Moderation.Domain.Tests;
+
+public class ModerationReviewTests
+{
+    private static readonly Guid ValidShopId = Guid.NewGuid();
+    private static readonly Guid ValidUserId = Guid.NewGuid();
+    private static readonly Guid ValidModerationShopId = Guid.NewGuid();
+    private const string ValidUserName = "user";
+    private const string ValidHeader = "Valid Header";
+    private const string ValidComment = "Valid comment text here";
+    private const int ValidRating = 3;
+
+    [Fact]
+    public void Create_WithNullModerationShopId_Succeeds()
+    {
+        var review = CreateReview(ValidShopId, moderationShopId: null);
+
+        review.ShopId.Should().Be(ValidShopId);
+        review.ModerationShopId.Should().BeNull();
+        review.Header.Should().Be(ValidHeader);
+        review.Comment.Should().Be(ValidComment);
+    }
+
+    [Fact]
+    public void Create_WithEmptyModerationShopId_StoresNull()
+    {
+        var review = CreateReview(ValidShopId, Guid.Empty);
+
+        review.ModerationShopId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_WithEmptyShopId_ThrowsDomainException()
+    {
+        var act = () => CreateReview(Guid.Empty, ValidModerationShopId);
+
+        act.Should().Throw<DomainException>().WithMessage("*shopId*");
+    }
+
+    [Fact]
+    public void Create_WithBlankHeader_ThrowsDomainException()
+    {
+        var act = () => CreateReview(ValidShopId, ValidModerationShopId, header: " ");
+
+        act.Should().Throw<DomainException>().WithMessage("*header*");
+    }
+
+    [Fact]
+    public void Create_WithHeaderTooShort_ThrowsDomainException()
+    {
+        var act = () => CreateReview(ValidShopId, ValidModerationShopId, header: "ab");
+
+        act.Should().Throw<DomainException>().WithMessage("*header*");
+    }
+
+    [Fact]
+    public void Create_WithBlankComment_ThrowsDomainException()
+    {
+        var act = () => CreateReview(ValidShopId, ValidModerationShopId, comment: "   ");
+
+        act.Should().Throw<DomainException>().WithMessage("*comment*");
+    }
+
+    [Fact]
+    public void Create_WithCommentTooShort_ThrowsDomainException()
+    {
+        var act = () => CreateReview(ValidShopId, ValidModerationShopId, comment: "Short");
+
+        act.Should().Throw<DomainException>().WithMessage("*comment*");
+    }
+
+    private static ModerationReview CreateReview(
+        Guid shopId,
+        Guid? moderationShopId,
+        string header = ValidHeader,
+        string comment = ValidComment)
+    {
+        return ModerationReview.Create(
+            ValidUserId,
+            shopId,
+            moderationShopId,
+            ValidUserName,
+            header,
+            comment,
+            ValidRating,
+            ValidRating,
+            ValidRating,
+            new List<PhotoMetadata>());
+    }
+}

--- a/CoffeePeek.Moderation.Domain/Aggregates/ModerationReviewAggregate/ModerationReview.Action.cs
+++ b/CoffeePeek.Moderation.Domain/Aggregates/ModerationReviewAggregate/ModerationReview.Action.cs
@@ -6,7 +6,7 @@ namespace CoffeePeek.Moderation.Domain.Aggregates.ModerationReviewAggregate;
 
 public partial class ModerationReview
 {
-    public static ModerationReview Create(Guid userId, Guid shopId, Guid moderationShopId, string userName, string header, string comment,
+    public static ModerationReview Create(Guid userId, Guid shopId, Guid? moderationShopId, string userName, string header, string comment,
         int ratingPlace, int ratingService, int ratingCoffee, List<PhotoMetadata> photos)
     {
         if (shopId == Guid.Empty)
@@ -14,9 +14,6 @@ public partial class ModerationReview
 
         if (userId == Guid.Empty)
             throw new DomainException($"{nameof(userId)} cannot be empty.");
-        
-        if (moderationShopId == Guid.Empty)
-            throw new DomainException($"{nameof(moderationShopId)} cannot be empty.");
 
         if (string.IsNullOrWhiteSpace(header))
             throw new DomainException("Review header is required.");

--- a/CoffeePeek.Moderation.Domain/Aggregates/ModerationReviewAggregate/ModerationReview.cs
+++ b/CoffeePeek.Moderation.Domain/Aggregates/ModerationReviewAggregate/ModerationReview.cs
@@ -11,7 +11,7 @@ public partial class ModerationReview : Entity<Guid>
     public Guid UserId { get; private set; }
     public string UserName { get; private set; }
     public Guid ShopId { get; private set; }
-    public Guid ModerationShopId { get; private set; }
+    public Guid? ModerationShopId { get; private set; }
 
     public Rating Rating { get; private set; }
 
@@ -33,13 +33,15 @@ public partial class ModerationReview : Entity<Guid>
     {
     }
 
-    internal ModerationReview(Guid userId, Guid shopId, Guid moderationShopId, string userName, string header, string comment,
+    internal ModerationReview(Guid userId, Guid shopId, Guid? moderationShopId, string userName, string header, string comment,
         Rating rating, List<PhotoMetadata> photos)
     {
         Id = Guid.NewGuid();
         UserId = userId;
         ShopId = shopId;
-        ModerationShopId = moderationShopId;
+        ModerationShopId = moderationShopId is null || moderationShopId == Guid.Empty
+            ? null
+            : moderationShopId;
         UserName = userName;
         Header = header;
         Comment = comment;

--- a/CoffeePeek.Moderation.Domain/Aggregates/ModerationReviewAggregate/Rating.cs
+++ b/CoffeePeek.Moderation.Domain/Aggregates/ModerationReviewAggregate/Rating.cs
@@ -36,6 +36,18 @@ public record Rating
     
     public void UpdateRating(int place, int service, int coffee)
     {
+        if (place is < BusinessConstants.MinReviewRate or > BusinessConstants.MaxReviewRate)
+            throw new DomainException(
+                $"{nameof(place)} must be between {BusinessConstants.MinReviewRate} and {BusinessConstants.MaxReviewRate}.");
+
+        if (service is < BusinessConstants.MinReviewRate or > BusinessConstants.MaxReviewRate)
+            throw new DomainException(
+                $"{nameof(service)} must be between {BusinessConstants.MinReviewRate} and {BusinessConstants.MaxReviewRate}.");
+
+        if (coffee is < BusinessConstants.MinReviewRate or > BusinessConstants.MaxReviewRate)
+            throw new DomainException(
+                $"{nameof(coffee)} must be between {BusinessConstants.MinReviewRate} and {BusinessConstants.MaxReviewRate}.");
+
         Place = place;
         Service = service;
         Coffee = coffee;

--- a/CoffeePeek.Moderation.Domain/Aggregates/ModerationShopAggregate/ModerationShop.Actions.cs
+++ b/CoffeePeek.Moderation.Domain/Aggregates/ModerationShopAggregate/ModerationShop.Actions.cs
@@ -97,14 +97,16 @@ public sealed partial class ModerationShop
             e => e.BrewMethodId);
     }
     
-    public void Approve()
+    public bool Approve()
     {
-        if (ModerationStatus == ModerationStatus.Approved) return;
+        if (ModerationStatus == ModerationStatus.Approved)
+            return false;
 
-        if (!Location!.IsAddressValidated)
+        if (Location is null || !Location.IsAddressValidated)
             throw new DomainException("Cannot approve shop with unvalidated address.");
 
         ModerationStatus = ModerationStatus.Approved;
+        return true;
     }
 
     public void Reject(string reason)

--- a/CoffeePeek.Moderation.Domain/Aggregates/ModerationShopAggregate/Specifications/DuplicateShopSpecification.cs
+++ b/CoffeePeek.Moderation.Domain/Aggregates/ModerationShopAggregate/Specifications/DuplicateShopSpecification.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq.Expressions;
+using CoffeePeek.Moderation.Domain.Common.Enums;
 using CoffeePeek.Shared.Domain.Interfaces.Persistance;
 
 namespace CoffeePeek.Moderation.Domain.Aggregates;
@@ -9,7 +10,8 @@ public class DuplicateShopSpecification : ISpecification<ModerationShop>
     {
         Criteria = shop =>
 #pragma warning disable CA1862
-            shop.Name.ToLower() == name.ToLower() && shop.Location!.Address.ToLower() == address.ToLower();
+            shop.Name.ToLower() == name.ToLower() && shop.Location!.Address.ToLower() == address.ToLower()
+            && shop.ModerationStatus != ModerationStatus.Rejected;
 #pragma warning restore CA1862
     }
 

--- a/CoffeePeek.Moderation.Domain/Aggregates/ShopImportCandidateAggregate/IShopImportCandidateRepository.cs
+++ b/CoffeePeek.Moderation.Domain/Aggregates/ShopImportCandidateAggregate/IShopImportCandidateRepository.cs
@@ -30,6 +30,7 @@ public sealed record ImportCandidateStats(
     int Skipped,
     int Published,
     int Rejected,
+    int InFeed,
     IReadOnlyDictionary<ImportCoffeeFocus, int> ByFocus,
     IReadOnlyDictionary<ImportCollectorBucket, int> ByBucket,
     ImportRejectedByReasonStats RejectedByReason);

--- a/CoffeePeek.Moderation.Domain/Aggregates/ShopImportCandidateAggregate/ShopImportCandidate.cs
+++ b/CoffeePeek.Moderation.Domain/Aggregates/ShopImportCandidateAggregate/ShopImportCandidate.cs
@@ -88,6 +88,9 @@ public sealed class ShopImportCandidate : Entity<Guid>
     public void RefreshFromOsm(OsmCandidateSnapshot snapshot, DateTimeOffset now)
     {
         ArgumentNullException.ThrowIfNull(snapshot);
+        if (QueueStatus is ImportQueueStatus.Published or ImportQueueStatus.Skipped)
+            return;
+
         ApplyOsmFields(snapshot, now);
     }
 
@@ -102,6 +105,9 @@ public sealed class ShopImportCandidate : Entity<Guid>
     {
         if (reviewerId == Guid.Empty)
             throw new DomainException("Reviewer is required.");
+
+        if (ResultingShopId is not null && status == ImportQueueStatus.Published)
+            throw new DomainException("Candidate is already published to the catalog.");
 
         if (status == ImportQueueStatus.Rejected)
         {

--- a/CoffeePeek.Moderation.Domain/Entities/PhotoMetadata.cs
+++ b/CoffeePeek.Moderation.Domain/Entities/PhotoMetadata.cs
@@ -9,13 +9,13 @@ public sealed class PhotoMetadata : Entity<Guid>
     public string StorageKey { get; private set; } 
     public long SizeBytes { get; private set; }
     public Guid OwnerId { get; private set; } 
-    public Guid ModerationShopId { get; private set; }
+    public Guid? ModerationShopId { get; private set; }
 
     // ReSharper disable once UnusedMember.Local
     private PhotoMetadata() { }
 
     private PhotoMetadata(string fileName, string contentType, string storageKey, long sizeBytes, Guid ownerId,
-        Guid moderationShopId)
+        Guid? moderationShopId)
     {
         Id = Guid.NewGuid();
         FileName = fileName;
@@ -23,10 +23,12 @@ public sealed class PhotoMetadata : Entity<Guid>
         StorageKey = storageKey;
         SizeBytes = sizeBytes;
         OwnerId = ownerId;
-        ModerationShopId = moderationShopId;
+        ModerationShopId = moderationShopId is null || moderationShopId == Guid.Empty
+            ? null
+            : moderationShopId;
     }
     
-    public static PhotoMetadata Create(string fileName, string contentType, string storageKey, long sizeBytes, Guid ownerId, Guid moderationShopId)
+    public static PhotoMetadata Create(string fileName, string contentType, string storageKey, long sizeBytes, Guid ownerId, Guid? moderationShopId)
     {
         return new PhotoMetadata(fileName, contentType, storageKey, sizeBytes, ownerId, moderationShopId);
     }

--- a/CoffeePeek.Moderation.Infrastructure/Consumers/ModerationShopApproveCompleteHandler.cs
+++ b/CoffeePeek.Moderation.Infrastructure/Consumers/ModerationShopApproveCompleteHandler.cs
@@ -1,21 +1,27 @@
 ﻿using CoffeePeek.Contract.Responses;
 using CoffeePeek.Moderation.Domain.Aggregates;
 using CoffeePeek.Shared.Kernel;
+using Microsoft.Extensions.Logging;
 
 namespace CoffeePeek.Moderation.Infrastructure.Consumers;
 
-public static class ModerationShopApproveCompleteHandler
+public class ModerationShopApproveCompleteHandler(
+    IModerationShopRepository repository,
+    IUnitOfWork unitOfWork,
+    ILogger<ModerationShopApproveCompleteHandler> logger)
 {
-    public static async Task Handle(
-        ModerationShopApproveCompleteResponse message,
-        IModerationShopRepository repository,
-        IUnitOfWork unitOfWork,
-        CancellationToken ct)
+    public async Task Handle(ModerationShopApproveCompleteResponse message, CancellationToken ct)
     {
-        var moderationShop = await repository.GetByIdWithOutDetails(message.ModerationShopId);
+        var moderationShop = await repository.GetByIdWithOutDetails(message.ModerationShopId, ct);
 
         if (moderationShop == null)
+        {
+            logger.LogWarning(
+                "Moderation shop {ModerationShopId} not found when completing approve for published shop {ShopId}",
+                message.ModerationShopId,
+                message.ShopId);
             return;
+        }
 
         moderationShop.AddShopId(message.ShopId);
 

--- a/CoffeePeek.ModerationService/Controllers/ModerationReviewsController.cs
+++ b/CoffeePeek.ModerationService/Controllers/ModerationReviewsController.cs
@@ -58,7 +58,8 @@ public class ModerationReviewsController(IMessageBus bus, IUserContext userConte
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
-    public async Task<IActionResult> SendReviewToModeration([FromBody] SendReviewToModerationCommand command)
+    public async Task<IActionResult> SendReviewToModeration(
+        [FromBody] SendReviewToModerationCommand command, CancellationToken ct)
     {
         command = command with
         {
@@ -66,24 +67,29 @@ public class ModerationReviewsController(IMessageBus bus, IUserContext userConte
             UserName = userContext.GetUsernameOrThrow()
         };
 
-        var response = await bus.InvokeAsync<CreateEntityResponse>(command);
+        var response = await bus.InvokeAsync<CreateEntityResponse>(command, ct);
 
-        return Ok(response);
+        return response.IsSuccess
+            ? Ok(response)
+            : StatusCode(response.StatusCode ?? StatusCodes.Status400BadRequest, response);
     }
 
     [HttpPut("{reviewId:guid}")]
+    [Authorize]
     [ProducesResponseType(typeof(Response<UpdateCoffeeShopReviewResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> UpdateReview(
-        [FromBody] UpdateCoffeeShopReviewCommand command, Guid reviewId)
+        [FromBody] UpdateCoffeeShopReviewCommand command, Guid reviewId, CancellationToken ct)
     {
         command = command with { UserId = userContext.GetUserIdOrThrow(), ReviewId = reviewId };
-        var response = await bus.InvokeAsync<Response<UpdateCoffeeShopReviewResponse>>(command);
+        var response = await bus.InvokeAsync<Response<UpdateCoffeeShopReviewResponse>>(command, ct);
 
-        return response.IsSuccess ? Ok(response) : NotFound(response);
+        return response.IsSuccess
+            ? Ok(response)
+            : StatusCode(response.StatusCode ?? StatusCodes.Status400BadRequest, response);
     }
 
     [HttpPut]
@@ -93,10 +99,12 @@ public class ModerationReviewsController(IMessageBus bus, IUserContext userConte
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
     public async Task<IActionResult> ChangeStatusModerationReview(
-        [FromBody] ChangeStatusModerationReviewCommand command)
+        [FromBody] ChangeStatusModerationReviewCommand command, CancellationToken ct)
     {
         var commandWithUser = command with { UserId = userContext.GetUserIdOrThrow() };
-        var response = await bus.InvokeAsync<UpdateEntityResponse<ModerationStatus>>(commandWithUser);
-        return Ok(response);
+        var response = await bus.InvokeAsync<UpdateEntityResponse<ModerationStatus>>(commandWithUser, ct);
+        return response.IsSuccess
+            ? Ok(response)
+            : StatusCode(response.StatusCode ?? StatusCodes.Status400BadRequest, response);
     }
 }

--- a/CoffeePeek.ModerationService/Controllers/ModerationShopsController.cs
+++ b/CoffeePeek.ModerationService/Controllers/ModerationShopsController.cs
@@ -52,6 +52,7 @@ public class ModerationShopsController(IMessageBus bus, IUserContext userContext
     }
 
     [HttpPost]
+    [Authorize]
     [Description("Adds a new coffee shop to moderation")]
     [ProducesResponseType<Response<SendCoffeeShopToModerationResponse>>(StatusCodes.Status201Created)]
     [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
@@ -80,7 +81,7 @@ public class ModerationShopsController(IMessageBus bus, IUserContext userContext
         var command = new UpdateModerationCoffeeShopCommand(dto, userId, isPrivilegedModerator);
 
         var response = await bus.InvokeAsync<UpdateEntityResponse<ModerationShopDto>>(command, ct);
-        return Ok(response);
+        return response.IsSuccess ? Ok(response) : NotFound(response);
     }
 
     [HttpPut("status")]
@@ -95,6 +96,8 @@ public class ModerationShopsController(IMessageBus bus, IUserContext userContext
             userContext.GetUserIdOrThrow(), id, status, comment);
 
         var response = await bus.InvokeAsync<Response>(request, ct);
-        return Ok(response);
+        return response.IsSuccess
+            ? Ok(response)
+            : StatusCode(response.StatusCode ?? StatusCodes.Status400BadRequest, response);
     }
 }

--- a/CoffeePeek.Shops.Application.Tests/Services/CreateShopFromModerationServiceTests.cs
+++ b/CoffeePeek.Shops.Application.Tests/Services/CreateShopFromModerationServiceTests.cs
@@ -58,8 +58,8 @@ public class CreateShopFromModerationServiceTests
     {
         // Arrange
         _shopRepoMock
-            .Setup(r => r.ExistsByModerationId(It.IsAny<Guid>(), _ct))
-            .ReturnsAsync(false);
+            .Setup(r => r.GetIdByModerationId(It.IsAny<Guid>(), _ct))
+            .ReturnsAsync((Guid?)null);
 
         var sut = CreateSut();
 
@@ -80,24 +80,25 @@ public class CreateShopFromModerationServiceTests
     }
 
     [Fact]
-    public async Task CreateShopFromApprovedEventAsync_WhenModerationIdAlreadyExists_ThrowsAndDoesNotAddOrSave()
+    public async Task CreateShopFromApprovedEventAsync_WhenModerationIdAlreadyExists_ReturnsExistingIdAndDoesNotAddOrSave()
     {
         // Arrange
+        var existingId = Guid.NewGuid();
         _shopRepoMock
-            .Setup(r => r.ExistsByModerationId(It.IsAny<Guid>(), _ct))
-            .ReturnsAsync(true);
+            .Setup(r => r.GetIdByModerationId(It.IsAny<Guid>(), _ct))
+            .ReturnsAsync(existingId);
 
         var sut = CreateSut();
 
         // Act
-        Func<Task> act = () => sut.CreateShopFromApprovedEventAsync(
+        var result = await sut.CreateShopFromApprovedEventAsync(
             CreateMinimalShopDto(),
             Guid.NewGuid(),
             Guid.NewGuid(),
             _ct);
 
-        // Assert — duplicate guard must throw before Add or SaveChangesAsync are reached
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        // Assert — duplicate guard returns the existing shop id without Add or SaveChangesAsync
+        result.Should().Be(existingId);
         _shopRepoMock.Verify(r => r.Add(It.IsAny<CoffeeShop>()), Times.Never);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }

--- a/CoffeePeek.Shops.Application/Services/CreateShopFromModerationService.cs
+++ b/CoffeePeek.Shops.Application/Services/CreateShopFromModerationService.cs
@@ -20,11 +20,14 @@ public class CreateShopFromModerationService(
 {
     public async Task<Guid> CreateShopFromApprovedEventAsync(ShopDto shopDto, Guid creatorId, Guid moderationId, CancellationToken cancellationToken = default)
     {
-        var exists = await shopRepository.ExistsByModerationId(moderationId, cancellationToken);
-        if (exists)
+        var existingId = await shopRepository.GetIdByModerationId(moderationId, cancellationToken);
+        if (existingId.HasValue)
         {
-            logger.LogInformation("Shop with ModerationId {ModerationId} already exists, skipping creation", moderationId);
-            throw new InvalidOperationException($"Shop with ModerationId {moderationId} already exists");
+            logger.LogInformation(
+                "Shop {ShopId} already exists for moderation {ModerationId}",
+                existingId.Value,
+                moderationId);
+            return existingId.Value;
         }
 
         var shop = new CoffeeShop(creatorId, shopDto.Name, shopDto.Description, (PriceRange)shopDto.PriceRange, moderationId);

--- a/CoffeeShop.Moderation.Persistence/Configuration/ModerationDbContext.cs
+++ b/CoffeeShop.Moderation.Persistence/Configuration/ModerationDbContext.cs
@@ -27,6 +27,11 @@ public class ModerationDbContext(DbContextOptions<ModerationDbContext> options) 
         {
             entity.UsePropertyAccessMode(PropertyAccessMode.Field);
             entity.HasKey(e => e.Id);
+            entity.HasOne<ModerationShop>()
+                .WithMany(s => s.ShopPhotos)
+                .HasForeignKey(e => e.ModerationShopId)
+                .IsRequired(false)
+                .OnDelete(DeleteBehavior.Cascade);
         });
         
         modelBuilder.Entity<ModerationShopEquipment>(entity =>

--- a/CoffeeShop.Moderation.Persistence/Configuration/ModerationReviewConfiguration.cs
+++ b/CoffeeShop.Moderation.Persistence/Configuration/ModerationReviewConfiguration.cs
@@ -12,7 +12,11 @@ public class ModerationReviewConfiguration : IEntityTypeConfiguration<Moderation
     {
         entity.UsePropertyAccessMode(PropertyAccessMode.Field);
         entity.HasKey(mr => mr.Id);
-        entity.HasOne(mr => mr.ModerationShop);
+        entity.HasOne(mr => mr.ModerationShop)
+            .WithMany()
+            .HasForeignKey(mr => mr.ModerationShopId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.Cascade);
             
         entity.HasIndex(mr => mr.ShopId);
         entity.HasIndex(mr => mr.UserId);

--- a/CoffeeShop.Moderation.Persistence/Migrations/20260815143500_NullableModerationShopIdOnReviews.Designer.cs
+++ b/CoffeeShop.Moderation.Persistence/Migrations/20260815143500_NullableModerationShopIdOnReviews.Designer.cs
@@ -3,17 +3,20 @@ using System;
 using CoffeeShop.Moderation.Persistence.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace CoffeePeek.Moderation.Infrastructure.Migrations
+namespace CoffeeShop.Moderation.Persistence.Migrations
 {
     [DbContext(typeof(ModerationDbContext))]
-    partial class ModerationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260815143500_NullableModerationShopIdOnReviews")]
+    partial class NullableModerationShopIdOnReviews
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CoffeeShop.Moderation.Persistence/Migrations/20260815143500_NullableModerationShopIdOnReviews.cs
+++ b/CoffeeShop.Moderation.Persistence/Migrations/20260815143500_NullableModerationShopIdOnReviews.cs
@@ -1,0 +1,103 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoffeeShop.Moderation.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class NullableModerationShopIdOnReviews : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModerationReviews_ModerationShops_ModerationShopId",
+                table: "ModerationReviews");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ShopPhotos_ModerationShops_ModerationShopId",
+                table: "ShopPhotos");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ModerationShopId",
+                table: "ShopPhotos",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ModerationShopId",
+                table: "ModerationReviews",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModerationReviews_ModerationShops_ModerationShopId",
+                table: "ModerationReviews",
+                column: "ModerationShopId",
+                principalTable: "ModerationShops",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ShopPhotos_ModerationShops_ModerationShopId",
+                table: "ShopPhotos",
+                column: "ModerationShopId",
+                principalTable: "ModerationShops",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ModerationReviews_ModerationShops_ModerationShopId",
+                table: "ModerationReviews");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ShopPhotos_ModerationShops_ModerationShopId",
+                table: "ShopPhotos");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ModerationShopId",
+                table: "ShopPhotos",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ModerationShopId",
+                table: "ModerationReviews",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ModerationReviews_ModerationShops_ModerationShopId",
+                table: "ModerationReviews",
+                column: "ModerationShopId",
+                principalTable: "ModerationShops",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ShopPhotos_ModerationShops_ModerationShopId",
+                table: "ShopPhotos",
+                column: "ModerationShopId",
+                principalTable: "ModerationShops",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/CoffeeShop.Moderation.Persistence/Repositories/ShopImportCandidateRepository.cs
+++ b/CoffeeShop.Moderation.Persistence/Repositories/ShopImportCandidateRepository.cs
@@ -75,27 +75,51 @@ public class ShopImportCandidateRepository(ModerationDbContext dbContext) : ISho
 
     public async Task<ImportCandidateStats> GetStatsAsync(CancellationToken ct = default)
     {
-        var rows = await dbContext.ShopImportCandidates
-            .AsNoTracking()
-            .Select(c => new { c.QueueStatus, c.CoffeeFocus, c.CollectorBucket, c.RejectReason })
+        var query = dbContext.ShopImportCandidates.AsNoTracking();
+
+        var statusCounts = await query
+            .GroupBy(c => c.QueueStatus)
+            .Select(g => new { Status = g.Key, Count = g.Count() })
             .ToListAsync(ct);
 
-        var rejected = rows.Where(r => r.QueueStatus == ImportQueueStatus.Rejected).ToList();
+        int CountOf(ImportQueueStatus status) =>
+            statusCounts.FirstOrDefault(x => x.Status == status)?.Count ?? 0;
+
+        var inFeed = await query.CountAsync(c => c.ResultingShopId != null, ct);
+
+        var byFocusRows = await query
+            .Where(c => c.CoffeeFocus != null)
+            .GroupBy(c => c.CoffeeFocus)
+            .Select(g => new { Focus = g.Key, Count = g.Count() })
+            .ToListAsync(ct);
+
+        var byFocus = byFocusRows
+            .Where(x => x.Focus.HasValue)
+            .ToDictionary(x => x.Focus!.Value, x => x.Count);
+
+        var byBucket = await query
+            .GroupBy(c => c.CollectorBucket)
+            .Select(g => new { Bucket = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.Bucket, x => x.Count, ct);
+
+        var rejectedReasons = await query
+            .Where(c => c.QueueStatus == ImportQueueStatus.Rejected)
+            .GroupBy(c => c.RejectReason)
+            .Select(g => new { Reason = g.Key, Count = g.Count() })
+            .ToListAsync(ct);
 
         return new ImportCandidateStats(
-            rows.Count(r => r.QueueStatus == ImportQueueStatus.Pending),
-            rows.Count(r => r.QueueStatus == ImportQueueStatus.Skipped),
-            rows.Count(r => r.QueueStatus == ImportQueueStatus.Published),
-            rejected.Count,
-            rows.Where(r => r.CoffeeFocus.HasValue)
-                .GroupBy(r => r.CoffeeFocus!.Value)
-                .ToDictionary(g => g.Key, g => g.Count()),
-            rows.GroupBy(r => r.CollectorBucket)
-                .ToDictionary(g => g.Key, g => g.Count()),
+            CountOf(ImportQueueStatus.Pending),
+            CountOf(ImportQueueStatus.Skipped),
+            CountOf(ImportQueueStatus.Published),
+            CountOf(ImportQueueStatus.Rejected),
+            inFeed,
+            byFocus,
+            byBucket,
             new ImportRejectedByReasonStats(
-                rejected.Count(r => r.RejectReason == ImportRejectReason.Closed),
-                rejected.Count(r => r.RejectReason == ImportRejectReason.Invalid),
-                rejected.Count(r => r.RejectReason == ImportRejectReason.NotCoffee),
-                rejected.Count(r => r.RejectReason is null)));
+                rejectedReasons.Where(r => r.Reason == ImportRejectReason.Closed).Sum(r => r.Count),
+                rejectedReasons.Where(r => r.Reason == ImportRejectReason.Invalid).Sum(r => r.Count),
+                rejectedReasons.Where(r => r.Reason == ImportRejectReason.NotCoffee).Sum(r => r.Count),
+                rejectedReasons.Where(r => r.Reason is null).Sum(r => r.Count)));
     }
 }


### PR DESCRIPTION
## Summary
- Idempotent shop approve (no duplicate events; Shops returns existing shop id).
- OSM-imported shops can enter review moderation (`ModerationShopId` nullable + migration).
- Import saga: no re-publish once in catalog; InFeed counts `ResultingShopId`; HTTP/validation hygiene.

## Test plan
- [ ] After deploy run `make up-mod` (NullableModerationShopIdOnReviews)
- [ ] Re-approve an already approved shop — no second catalog row / no extra AddedShopsCount
- [ ] Leave a review on an OSM-imported shop — 201, appears in moderation queue
- [ ] Admin overview InFeed ≠ Published when some publishes have not landed


Made with [Cursor](https://cursor.com)