### PR TITLE
Dev

### DIFF
--- a/CoffeePeek.Account.Application.Tests/Features/Auth/AuthService/AuthServiceTests.cs
+++ b/CoffeePeek.Account.Application.Tests/Features/Auth/AuthService/AuthServiceTests.cs
@@ -69,7 +69,7 @@ public class AuthServiceTests
     }
 
     [Fact]
-    public async Task LoginAsync_WithNonExistentEmail_ThrowsNotFoundException()
+    public async Task LoginAsync_WithNonExistentEmail_ThrowsUnauthorizedException()
     {
         // Arrange
         _userRepoMock.Setup(r => r.GetByEmail(It.IsAny<string>(), _ct)).ReturnsAsync((DomainUser?)null);
@@ -78,7 +78,7 @@ public class AuthServiceTests
         Func<Task> act = () => CreateSut().LoginAsync("nobody@example.com", "pass", "device", "ip");
 
         // Assert
-        await act.Should().ThrowAsync<NotFoundException>().WithMessage("User not found");
+        await act.Should().ThrowAsync<UnauthorizedException>().WithMessage("Invalid credentials");
     }
 
     [Fact]

--- a/CoffeePeek.Account.Application.Tests/Features/Auth/CheckUserExistsByEmail/CheckUserExistsByEmailHandlerTests.cs
+++ b/CoffeePeek.Account.Application.Tests/Features/Auth/CheckUserExistsByEmail/CheckUserExistsByEmailHandlerTests.cs
@@ -1,0 +1,58 @@
+using System.Threading;
+using System.Threading.Tasks;
+using CoffeePeek.Account.Application.Common;
+using CoffeePeek.Account.Application.Features.Auth.CheckUserExistsByEmail;
+using CoffeePeek.Account.Domain.Entities.UserAggregate;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace CoffeePeek.Account.Application.Tests.Features.Auth.CheckUserExistsByEmail;
+
+public class CheckUserExistsByEmailHandlerTests
+{
+    private readonly Mock<IQueryUserRepository> _userRepoMock = new();
+    private readonly EmailExistenceFilter _filter = new(1000, 0.01);
+    private readonly CancellationToken _ct = CancellationToken.None;
+
+    [Fact]
+    public async Task Handle_WhenUserExists_ReturnsSuccessTrue()
+    {
+        const string email = "user@example.com";
+        _userRepoMock.Setup(r => r.UserExistsByEmail(email, _ct)).ReturnsAsync(true);
+
+        var response = await CheckUserExistsByEmailRequestHandler.Handle(
+            new CheckUserExistsByEmailCommand(email), _userRepoMock.Object, _filter, _ct);
+
+        response.IsSuccess.Should().BeTrue();
+        response.Data.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserDoesNotExist_ReturnsSuccessFalse()
+    {
+        const string email = "nobody@example.com";
+        _userRepoMock.Setup(r => r.UserExistsByEmail(email, _ct)).ReturnsAsync(false);
+
+        var response = await CheckUserExistsByEmailRequestHandler.Handle(
+            new CheckUserExistsByEmailCommand(email), _userRepoMock.Object, _filter, _ct);
+
+        response.IsSuccess.Should().BeTrue();
+        response.Data.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WhenBloomFilterHitsButDbSaysMissing_ReturnsSuccessFalse()
+    {
+        const string email = "ghost@example.com";
+        _filter.Add(email);
+        _userRepoMock.Setup(r => r.UserExistsByEmail(email, _ct)).ReturnsAsync(false);
+
+        var response = await CheckUserExistsByEmailRequestHandler.Handle(
+            new CheckUserExistsByEmailCommand(email), _userRepoMock.Object, _filter, _ct);
+
+        response.IsSuccess.Should().BeTrue();
+        response.Data.Should().BeFalse();
+        _userRepoMock.Verify(r => r.UserExistsByEmail(email, _ct), Times.Once);
+    }
+}

--- a/CoffeePeek.Account.Application.Tests/Features/Auth/Login/LoginUserHandlerTests.cs
+++ b/CoffeePeek.Account.Application.Tests/Features/Auth/Login/LoginUserHandlerTests.cs
@@ -57,27 +57,27 @@ public class LoginUserHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenAuthServiceThrows_PropagatesException()
+    public async Task Handle_WhenAuthServiceThrowsUnauthorized_PropagatesException()
     {
         // Arrange
         var command = CreateCommand();
         _authServiceMock.Setup(s => s.LoginAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .ThrowsAsync(new NotFoundException("User not found"));
+            .ThrowsAsync(new UnauthorizedException("Invalid credentials"));
 
         // Act
         Func<Task> act = () => LoginUserHandler.Handle(command, _authServiceMock.Object, _filter, _ct);
 
         // Assert
-        await act.Should().ThrowAsync<NotFoundException>();
+        await act.Should().ThrowAsync<UnauthorizedException>().WithMessage("Invalid credentials");
     }
 
     [Fact]
-    public async Task Handle_WhenAuthServiceThrows_DoesNotAddEmailToFilter()
+    public async Task Handle_WhenAuthServiceThrowsUnauthorized_DoesNotAddEmailToFilter()
     {
         // Arrange
         var command = CreateCommand("ghost@example.com");
         _authServiceMock.Setup(s => s.LoginAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .ThrowsAsync(new NotFoundException("User not found"));
+            .ThrowsAsync(new UnauthorizedException("Invalid credentials"));
 
         // Act
         try { await LoginUserHandler.Handle(command, _authServiceMock.Object, _filter, _ct); } catch { }

--- a/CoffeePeek.Account.Application.Tests/Features/Auth/OAuth/ExternalAuthServiceTests.cs
+++ b/CoffeePeek.Account.Application.Tests/Features/Auth/OAuth/ExternalAuthServiceTests.cs
@@ -23,6 +23,8 @@ public class ExternalAuthServiceTests
     public ExternalAuthServiceTests()
     {
         _roleRepoMock.Setup(r => r.GetRoleAsync(RoleConsts.User)).ReturnsAsync(Role.Create(RoleConsts.User));
+        _queryRepoMock.Setup(r => r.IsUsernameUnique(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
     }
 
     [Fact]
@@ -84,5 +86,38 @@ public class ExternalAuthServiceTests
         _queryRepoMock.Setup(r => r.GetByEmail(It.IsAny<string>(), _ct)).ReturnsAsync((DomainUser?)null);
         var result = await CreateSut().GetOrCreate("user@google.com", "google", "id", _ct);
         result.Credentials.EmailConfirmed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetOrCreate_WhenUsernameTaken_AllocatesUniqueSuffix()
+    {
+        _queryRepoMock.Setup(r => r.GetByProvider(It.IsAny<string>(), It.IsAny<string>(), _ct)).ReturnsAsync((DomainUser?)null);
+        _queryRepoMock.Setup(r => r.GetByEmail(It.IsAny<string>(), _ct)).ReturnsAsync((DomainUser?)null);
+        _queryRepoMock.SetupSequence(r => r.IsUsernameUnique(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false)
+            .ReturnsAsync(true);
+
+        var result = await CreateSut().GetOrCreate("newuser@google.com", "google", "new_id", _ct);
+
+        result.Username.Value.Should().StartWith("newuser");
+        result.Username.Value.Length.Should().BeInRange(3, 30);
+        char.IsLetter(result.Username.Value[0]).Should().BeTrue();
+        result.Username.Value.Should().NotBe("newuser");
+        _queryRepoMock.Verify(r => r.Add(result, _ct), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetOrCreate_WhenUsernameCannotBeAllocated_ThrowsDomainException()
+    {
+        _queryRepoMock.Setup(r => r.GetByProvider(It.IsAny<string>(), It.IsAny<string>(), _ct)).ReturnsAsync((DomainUser?)null);
+        _queryRepoMock.Setup(r => r.GetByEmail(It.IsAny<string>(), _ct)).ReturnsAsync((DomainUser?)null);
+        _queryRepoMock.Setup(r => r.IsUsernameUnique(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        Func<Task> act = () => CreateSut().GetOrCreate("newuser@google.com", "google", "new_id", _ct);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Could not allocate a unique username");
+        _queryRepoMock.Verify(r => r.Add(It.IsAny<DomainUser>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/CoffeePeek.Account.Application.Tests/Features/Auth/OAuth/GoogleLoginHandlerTests.cs
+++ b/CoffeePeek.Account.Application.Tests/Features/Auth/OAuth/GoogleLoginHandlerTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using CoffeePeek.Account.Application.Common.Interfaces;
+using CoffeePeek.Account.Application.Features.Auth.OAuthLogin;
+using CoffeePeek.Account.Domain.Entities.RoleAggregate;
+using CoffeePeek.Account.Domain.Services;
+using CoffeePeek.Shared.Auth.Options;
+using CoffeePeek.Shared.Kernel;
+using CoffeePeek.Shared.Kernel.Response;
+using FluentAssertions;
+using Google.Apis.Auth;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace CoffeePeek.Account.Application.Tests.Features.Auth.OAuth;
+
+public class GoogleLoginHandlerTests
+{
+    private readonly Mock<IGoogleAuthService> _googleAuthMock = new();
+    private readonly Mock<IExternalAuthService> _externalAuthMock = new();
+    private readonly Mock<IJWTTokenService> _tokenServiceMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly IOptions<JWTOptions> _jwtOptions = Options.Create(new JWTOptions
+    {
+        SecretKey = "test-secret-key-must-be-32-chars!",
+        Issuer = "TestIssuer",
+        Audience = "TestAudience",
+        AccessTokenLifetimeMinutes = 15,
+        RefreshTokenLifetimeDays = 7
+    });
+    private readonly CancellationToken _ct = CancellationToken.None;
+
+    private Task<Response<GoogleLoginResponse>> Handle(GoogleLoginCommand command) =>
+        GoogleLoginHandler.Handle(
+            command,
+            _googleAuthMock.Object,
+            _externalAuthMock.Object,
+            _tokenServiceMock.Object,
+            _jwtOptions,
+            _unitOfWorkMock.Object,
+            _ct);
+
+    [Fact]
+    public async Task Handle_WhenPayloadIsNull_ReturnsInvalidTokenWithoutGetOrCreate()
+    {
+        _googleAuthMock.Setup(s => s.ValidateIdTokenAsync("bad-token", _ct))
+            .ReturnsAsync((GoogleJsonWebSignature.Payload?)null);
+
+        var response = await Handle(new GoogleLoginCommand("bad-token"));
+
+        response.IsSuccess.Should().BeFalse();
+        response.Message.Should().Be("Invalid token");
+        _externalAuthMock.Verify(
+            s => s.GetOrCreate(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenEmailNotVerified_ReturnsBadRequestWithoutGetOrCreate()
+    {
+        _googleAuthMock.Setup(s => s.ValidateIdTokenAsync("id-token", _ct))
+            .ReturnsAsync(new GoogleJsonWebSignature.Payload
+            {
+                Email = "user@gmail.com",
+                EmailVerified = false,
+                Subject = "google-sub"
+            });
+
+        var response = await Handle(new GoogleLoginCommand("id-token"));
+
+        response.IsSuccess.Should().BeFalse();
+        response.StatusCode.Should().Be((int)HttpStatusCode.BadRequest);
+        response.Message.Should().Be("Google email is not verified.");
+        _externalAuthMock.Verify(
+            s => s.GetOrCreate(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenEmailVerified_CreatesSession()
+    {
+        var user = DomainUser.CreateExternal("user@gmail.com", "google", "google-sub");
+        user.AssignRole(Role.Create("User"));
+
+        _googleAuthMock.Setup(s => s.ValidateIdTokenAsync("id-token", _ct))
+            .ReturnsAsync(new GoogleJsonWebSignature.Payload
+            {
+                Email = "user@gmail.com",
+                EmailVerified = true,
+                Subject = "google-sub",
+                Picture = "https://example.com/avatar.png"
+            });
+        _externalAuthMock.Setup(s => s.GetOrCreate("user@gmail.com", "GoogleProvider", "google-sub", _ct))
+            .ReturnsAsync(user);
+        _tokenServiceMock.Setup(s => s.GenerateAccessToken(user)).Returns("access");
+        _tokenServiceMock.Setup(s => s.GenerateRefreshToken()).Returns("refresh");
+
+        var response = await Handle(new GoogleLoginCommand("id-token", "Chrome", "127.0.0.1"));
+
+        response.IsSuccess.Should().BeTrue();
+        response.Data!.AccessToken.Should().Be("access");
+        response.Data.RefreshToken.Should().Be("refresh");
+        response.Data.User.Email.Should().Be("user@gmail.com");
+        user.RefreshTokens.Should().ContainSingle(t => t.IsActive && t.Token == "refresh");
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(_ct), Times.Once);
+    }
+}

--- a/CoffeePeek.Account.Application.Tests/Features/Auth/Register/RegisterUserHandlerTests.cs
+++ b/CoffeePeek.Account.Application.Tests/Features/Auth/Register/RegisterUserHandlerTests.cs
@@ -30,6 +30,7 @@ public class RegisterUserHandlerTests
     public RegisterUserHandlerTests()
     {
         _queryRepoMock.Setup(r => r.IsEmailUnique(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _queryRepoMock.Setup(r => r.IsUsernameUnique(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
         _roleRepoMock.Setup(r => r.GetRoleAsync(RoleConsts.User)).ReturnsAsync(Role.Create(RoleConsts.User));
         _hasherMock.Setup(h => h.HashPassword(It.IsAny<string>())).Returns("hashed_password");
     }
@@ -59,13 +60,22 @@ public class RegisterUserHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenEmailInBloomFilter_ThrowsDomainException()
+    public async Task Handle_WhenEmailInBloomFilter_StillChecksUniquenessAndSucceeds()
     {
         const string email = "taken@example.com";
         _filter.Add(email);
-        Func<Task> act = () => RegisterUserHandler.Handle(CreateCommand(email: email), _queryRepoMock.Object, _roleRepoMock.Object, _hasherMock.Object, _filter, _unitOfWorkMock.Object, _ct);
-        await act.Should().ThrowAsync<DomainException>().WithMessage("Email already exists");
-        _queryRepoMock.Verify(r => r.IsEmailUnique(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        var (response, @event) = await RegisterUserHandler.Handle(CreateCommand(email: email), _queryRepoMock.Object, _roleRepoMock.Object, _hasherMock.Object, _filter, _unitOfWorkMock.Object, _ct);
+        response.IsSuccess.Should().BeTrue();
+        @event.Email.Should().Be(email);
+        _queryRepoMock.Verify(r => r.IsEmailUnique(email, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUsernameNotUniqueInDb_ThrowsDomainException()
+    {
+        _queryRepoMock.Setup(r => r.IsUsernameUnique(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        Func<Task> act = () => RegisterUserHandler.Handle(CreateCommand(), _queryRepoMock.Object, _roleRepoMock.Object, _hasherMock.Object, _filter, _unitOfWorkMock.Object, _ct);
+        await act.Should().ThrowAsync<DomainException>().WithMessage("Username already exists");
     }
 
     [Fact]

--- a/CoffeePeek.Account.Application.Tests/Features/User/DeleteUser/DeleteUserHandlerTests.cs
+++ b/CoffeePeek.Account.Application.Tests/Features/User/DeleteUser/DeleteUserHandlerTests.cs
@@ -43,6 +43,19 @@ public class DeleteUserHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WhenUserHasActiveSession_RevokesAllSessions()
+    {
+        var user = CreateUser();
+        user.AddSession("token", TimeSpan.FromDays(7), "dev", "127.0.0.1");
+        _userRepoMock.Setup(r => r.GetById(user.Id, _ct)).ReturnsAsync(user);
+
+        await DeleteUserHandler.Handle(new DeleteUserCommand(user.Id), _userRepoMock.Object, _unitOfWorkMock.Object, _ct);
+
+        user.RefreshTokens.Should().OnlyContain(t => !t.IsActive);
+        user.IsSoftDelete.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task Handle_WhenUserExists_CallsUpdateAndSaveChanges()
     {
         var user = CreateUser();

--- a/CoffeePeek.Account.Application.Tests/Features/User/GetProfile/GetProfileHandlerTests.cs
+++ b/CoffeePeek.Account.Application.Tests/Features/User/GetProfile/GetProfileHandlerTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CoffeePeek.Account.Application.Features.User.GetProfile;
+using CoffeePeek.Account.Domain.Entities.RoleAggregate;
+using CoffeePeek.Account.Domain.Entities.UserAggregate;
+using CoffeePeek.Shared.Kernel.Exceptions;
+using FluentAssertions;
+using MapsterMapper;
+using Moq;
+using Xunit;
+
+namespace CoffeePeek.Account.Application.Tests.Features.User.GetProfile;
+
+public class GetProfileHandlerTests
+{
+    private readonly Mock<IUserRepository> _userRepoMock = new();
+    private readonly Mock<IMapper> _mapperMock = new();
+    private readonly CancellationToken _ct = CancellationToken.None;
+
+    private static DomainUser CreateUser()
+    {
+        var role = Role.Create("User");
+        return DomainUser.Register("user@example.com", "testuser", "hash", role);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserExists_ReturnsProfileWithEmail()
+    {
+        var user = CreateUser();
+        var profile = new UserProfileResponse(
+            "testuser", "user@example.com", DateTime.UtcNow, null, null, 0, 0, 0);
+        _userRepoMock.Setup(r => r.GetById(user.Id, _ct)).ReturnsAsync(user);
+        _mapperMock.Setup(m => m.Map<UserProfileResponse>(user)).Returns(profile);
+
+        var result = await GetProfileHandler.Handle(
+            new GetProfileCommand(user.Id), _userRepoMock.Object, _mapperMock.Object, _ct);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.Email.Should().Be("user@example.com");
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserNotFound_ThrowsNotFoundException()
+    {
+        _userRepoMock.Setup(r => r.GetById(It.IsAny<Guid>(), _ct)).ReturnsAsync((DomainUser?)null);
+
+        Func<Task> act = () => GetProfileHandler.Handle(
+            new GetProfileCommand(Guid.NewGuid()), _userRepoMock.Object, _mapperMock.Object, _ct);
+
+        await act.Should().ThrowAsync<NotFoundException>().WithMessage("User not found");
+    }
+}
+
+public class GetPublicUserProfileHandlerTests
+{
+    private readonly Mock<IUserRepository> _userRepoMock = new();
+    private readonly Mock<IMapper> _mapperMock = new();
+    private readonly GetPublicUserProfileHandler _handler = new();
+    private readonly CancellationToken _ct = CancellationToken.None;
+
+    private static DomainUser CreateUser()
+    {
+        var role = Role.Create("User");
+        return DomainUser.Register("user@example.com", "testuser", "hash", role);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserExists_ReturnsPublicProfileWithoutEmail()
+    {
+        var user = CreateUser();
+        var profile = new PublicUserProfileResponse(
+            "testuser", DateTime.UtcNow, null, null, 0, 0, 0);
+        _userRepoMock.Setup(r => r.GetById(user.Id, _ct)).ReturnsAsync(user);
+        _mapperMock.Setup(m => m.Map<PublicUserProfileResponse>(user)).Returns(profile);
+
+        var result = await _handler.Handle(
+            new GetPublicUserProfileCommand(user.Id), _userRepoMock.Object, _mapperMock.Object, _ct);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data.Should().Be(profile);
+        result.Data!.GetType().GetProperty("Email").Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserNotFound_ThrowsNotFoundException()
+    {
+        _userRepoMock.Setup(r => r.GetById(It.IsAny<Guid>(), _ct)).ReturnsAsync((DomainUser?)null);
+
+        Func<Task> act = () => _handler.Handle(
+            new GetPublicUserProfileCommand(Guid.NewGuid()), _userRepoMock.Object, _mapperMock.Object, _ct);
+
+        await act.Should().ThrowAsync<NotFoundException>().WithMessage("User not found");
+    }
+}

--- a/CoffeePeek.Account.Application/Features/Auth/CheckUserExistsByEmail/CheckUserExistsByEmailHandler.cs
+++ b/CoffeePeek.Account.Application/Features/Auth/CheckUserExistsByEmail/CheckUserExistsByEmailHandler.cs
@@ -1,24 +1,18 @@
 ﻿using CoffeePeek.Account.Application.Common;
 using CoffeePeek.Account.Domain.Entities.UserAggregate;
-using CoffeePeek.Shared.Kernel.Exceptions;
 using CoffeePeek.Shared.Kernel.Response;
 
 namespace CoffeePeek.Account.Application.Features.Auth.CheckUserExistsByEmail;
 
 public class CheckUserExistsByEmailRequestHandler
 {
-    public static async Task<Response<bool>> Handle(CheckUserExistsByEmailCommand command, IQueryUserRepository userRepository,
-        EmailExistenceFilter emailExistenceFilter, CancellationToken cancellationToken)
+    public static async Task<Response<bool>> Handle(
+        CheckUserExistsByEmailCommand command,
+        IQueryUserRepository userRepository,
+        EmailExistenceFilter emailExistenceFilter,
+        CancellationToken cancellationToken)
     {
-        if (emailExistenceFilter.MightExist(command.Email))
-        {
-            return Response<bool>.Success(true, "Email exists");
-        }
-
-        var userExists = await userRepository.UserExistsByEmail(command.Email, cancellationToken);
-
-        return userExists
-            ? Response<bool>.Success(true, "Email exists")
-            : throw new NotFoundException("Email does not exist");
+        var exists = await userRepository.UserExistsByEmail(command.Email, cancellationToken);
+        return Response<bool>.Success(exists);
     }
 }

--- a/CoffeePeek.Account.Application/Features/Auth/Login/AuthService.cs
+++ b/CoffeePeek.Account.Application/Features/Auth/Login/AuthService.cs
@@ -19,14 +19,9 @@ public class AuthService(
         var user = await userRepository.GetByEmail(email, cancellationToken);
 
         if (user == null)
-        {
-            throw new NotFoundException("User not found");
-        }
-
-        if (!user.Credentials.ValidatePassword(password, passwordHasher))
-        {
             throw new UnauthorizedException("Invalid credentials");
-        }
+        if (!user.Credentials.ValidatePassword(password, passwordHasher))
+            throw new UnauthorizedException("Invalid credentials");
 
         if (!user.Credentials.EmailConfirmed)
         {

--- a/CoffeePeek.Account.Application/Features/Auth/OAuthLogin/ExternalAuthService.cs
+++ b/CoffeePeek.Account.Application/Features/Auth/OAuthLogin/ExternalAuthService.cs
@@ -12,6 +12,10 @@ public class ExternalAuthService(
     IQueryUserRepository userRepository,
     IRoleRepository roleRepository) : IExternalAuthService
 {
+    private const int UsernameSuffixLength = 4;
+    private const int MaxUsernameLength = 30;
+    private const int UniqueUsernameAttempts = 5;
+
     public async Task<User> GetOrCreate(string email, string provider, string providerId,
         CancellationToken ct)
     {
@@ -28,6 +32,8 @@ public class ExternalAuthService(
                 "An account with this email already exists. Please log in with your email and password and link the external provider from your profile settings.");
 
         var newUser = User.CreateExternal(email, provider, providerId);
+        if (!await userRepository.IsUsernameUnique(newUser.Username, ct))
+            newUser = await CreateWithUniqueUsername(email, provider, providerId, newUser.Username, ct);
 
         var role = await roleRepository.GetRoleAsync(RoleConsts.User)
                    ?? throw new ApplicationException($"Role {RoleConsts.User} not found");
@@ -35,5 +41,44 @@ public class ExternalAuthService(
         newUser.AssignRole(role);
         userRepository.Add(newUser, ct);
         return newUser;
+    }
+
+    private async Task<User> CreateWithUniqueUsername(
+        string email,
+        string provider,
+        string providerId,
+        string baseSanitizedName,
+        CancellationToken ct)
+    {
+        var baseName = TrimForSuffix(baseSanitizedName);
+
+        for (var attempt = 0; attempt < UniqueUsernameAttempts; attempt++)
+        {
+            var suffix = Guid.NewGuid().ToString("N")[..UsernameSuffixLength];
+            var candidate = baseName + suffix;
+            if (await userRepository.IsUsernameUnique(candidate, ct))
+                return User.CreateExternal(email, provider, providerId, candidate);
+        }
+
+        throw new DomainException("Could not allocate a unique username");
+    }
+
+    private static string TrimForSuffix(string baseSanitizedName)
+    {
+        var maxBaseLength = MaxUsernameLength - UsernameSuffixLength;
+        var baseName = baseSanitizedName.Length > maxBaseLength
+            ? baseSanitizedName[..maxBaseLength]
+            : baseSanitizedName;
+
+        if (baseName.Length == 0 || !char.IsLetter(baseName[0]))
+            baseName = "user" + baseName;
+
+        if (baseName.Length < 3)
+            baseName = baseName.PadRight(3, '0');
+
+        if (baseName.Length > maxBaseLength)
+            baseName = baseName[..maxBaseLength];
+
+        return baseName;
     }
 }

--- a/CoffeePeek.Account.Application/Features/Auth/OAuthLogin/OAuthLoginHandler.cs
+++ b/CoffeePeek.Account.Application/Features/Auth/OAuthLogin/OAuthLoginHandler.cs
@@ -23,6 +23,9 @@ public static class GoogleLoginHandler
         if (payload is null)
             return Response<GoogleLoginResponse>.Error("Invalid token");
 
+        if (payload.EmailVerified is not true)
+            return Response<GoogleLoginResponse>.Error(System.Net.HttpStatusCode.BadRequest, "Google email is not verified.");
+
         var user = await externalAuthService.GetOrCreate(
             payload.Email,
             ProviderConsts.GoogleProvider,

--- a/CoffeePeek.Account.Application/Features/Auth/RegisterUser/RegisterUserHandler.cs
+++ b/CoffeePeek.Account.Application/Features/Auth/RegisterUser/RegisterUserHandler.cs
@@ -20,8 +20,11 @@ public static class RegisterUserHandler
         IUnitOfWork unitOfWork,
         CancellationToken ct)
     {
-        if (emailExistenceFilter.MightExist(request.Email) || !await userRepository.IsEmailUnique(request.Email, ct))
+        if (!await userRepository.IsEmailUnique(request.Email, ct))
             throw new DomainException("Email already exists");
+
+        if (!await userRepository.IsUsernameUnique(request.UserName, ct))
+            throw new DomainException("Username already exists");
 
         if (string.IsNullOrWhiteSpace(request.Password) || request.Password.Length < 8)
             throw new DomainException("Password must be at least 8 characters long");

--- a/CoffeePeek.Account.Application/Features/User/DeleteUser/DeleteUserHandler.cs
+++ b/CoffeePeek.Account.Application/Features/User/DeleteUser/DeleteUserHandler.cs
@@ -20,6 +20,7 @@ public class DeleteUserHandler
             return Response<bool>.Error("User not found");
         }
 
+        user.RevokeAllSessions();
         user.SetSoftDelete();
 
         await userRepository.Update(user, cancellationToken);

--- a/CoffeePeek.Account.Application/Features/User/GetProfile/GetProfileHandler.cs
+++ b/CoffeePeek.Account.Application/Features/User/GetProfile/GetProfileHandler.cs
@@ -1,4 +1,5 @@
 using CoffeePeek.Account.Domain.Entities.UserAggregate;
+using CoffeePeek.Shared.Kernel.Exceptions;
 using CoffeePeek.Shared.Kernel.Response;
 using MapsterMapper;
 
@@ -12,12 +13,11 @@ public class GetProfileHandler
 
         if (user == null)
         {
-            return Response<UserProfileResponse>.Error("User not found.");
+            throw new NotFoundException("User not found");
         }
-        
-        
+
         var result = mapper.Map<UserProfileResponse>(user);
-        
+
         return Response<UserProfileResponse>.Success(result);
     }
 }

--- a/CoffeePeek.Account.Application/Features/User/GetProfile/GetPublicUserProfileHandler.cs
+++ b/CoffeePeek.Account.Application/Features/User/GetProfile/GetPublicUserProfileHandler.cs
@@ -2,16 +2,15 @@ using CoffeePeek.Account.Domain.Entities.UserAggregate;
 using CoffeePeek.Shared.Kernel.Exceptions;
 using CoffeePeek.Shared.Kernel.Response;
 using MapsterMapper;
-using Wolverine.Attributes;
 
 namespace CoffeePeek.Account.Application.Features.User.GetProfile;
 
 public class GetPublicUserProfileHandler
 {
-    public async Task<Response<UserProfileResponse>> Handle(
-        GetPublicUserProfileCommand command, 
-        IUserRepository userRepository, 
-        IMapper mapper, 
+    public async Task<Response<PublicUserProfileResponse>> Handle(
+        GetPublicUserProfileCommand command,
+        IUserRepository userRepository,
+        IMapper mapper,
         CancellationToken ct)
     {
         var user = await userRepository.GetById(command.UserId, ct);
@@ -21,8 +20,8 @@ public class GetPublicUserProfileHandler
             throw new NotFoundException("User not found");
         }
 
-        var result = mapper.Map<UserProfileResponse>(user);
-        
-        return Response<UserProfileResponse>.Success(result);
+        var result = mapper.Map<PublicUserProfileResponse>(user);
+
+        return Response<PublicUserProfileResponse>.Success(result);
     }
 }

--- a/CoffeePeek.Account.Application/Features/User/GetProfile/PublicUserProfileResponse.cs
+++ b/CoffeePeek.Account.Application/Features/User/GetProfile/PublicUserProfileResponse.cs
@@ -1,0 +1,10 @@
+namespace CoffeePeek.Account.Application.Features.User.GetProfile;
+
+public record PublicUserProfileResponse(
+    string UserName,
+    DateTime CreatedAtUtc,
+    string? About,
+    string? AvatarUrl,
+    int ReviewCount,
+    int CheckInCount,
+    int AddedShopsCount);

--- a/CoffeePeek.Account.Application/Mapper/MapsterConfiguration.cs
+++ b/CoffeePeek.Account.Application/Mapper/MapsterConfiguration.cs
@@ -32,6 +32,18 @@ public static class MapsterConfiguration
                     src.PhotoMetadata!.StorageKey)
                 : null);
 
+        config.NewConfig<User, PublicUserProfileResponse>()
+            .Map(d => d.UserName, s => s.Username.Value)
+            .Map(dest => dest.ReviewCount, src => src.Statistics.ReviewCount)
+            .Map(dest => dest.CheckInCount, src => src.Statistics.CheckInCount)
+            .Map(dest => dest.AddedShopsCount, src => src.Statistics.AddedShopsCount)
+            .Map(dest => dest.AvatarUrl, src => src.PhotoMetadata != null
+                ? MediaStorageUrlBuilder.BuildPublicUrl(
+                    mediaOptions.PublicEndpoint,
+                    mediaOptions.AvatarBucketName,
+                    src.PhotoMetadata!.StorageKey)
+                : null);
+
         return config;
     }
 }

--- a/CoffeePeek.Account.Domain.Tests/UserTests.cs
+++ b/CoffeePeek.Account.Domain.Tests/UserTests.cs
@@ -86,6 +86,29 @@ public class UserTests
     }
 
     [Fact]
+    public void CreateExternal_WithUsernameOverride_ShouldUseOverride()
+    {
+        var user = User.CreateExternal("test@example.com", "google", "google_123", "customuser");
+
+        user.Username.Value.Should().Be("customuser");
+        user.Credentials.Email.Value.Should().Be("test@example.com");
+    }
+
+    [Fact]
+    public void ChangePassword_ShouldRevokeAllRefreshSessions()
+    {
+        var user = User.Register("test@example.com", "testuser", "old_hash", Role.Create("User"));
+        user.AddSession("refresh1", TimeSpan.FromHours(1), "device", "127.0.0.1");
+        user.AddSession("refresh2", TimeSpan.FromHours(1), "device", "127.0.0.1");
+
+        user.ChangePassword("new_hash");
+
+        user.Credentials.PasswordHash.Should().Be("new_hash");
+        user.RefreshTokens.Should().OnlyContain(t => !t.IsActive);
+        user.RefreshTokens.Should().HaveCount(2);
+    }
+
+    [Fact]
     public void AddSession_ShouldAddRefreshToken()
     {
         // Arrange

--- a/CoffeePeek.Account.Domain/Entities/UserAggregate/IQueryUserRepository.cs
+++ b/CoffeePeek.Account.Domain/Entities/UserAggregate/IQueryUserRepository.cs
@@ -8,4 +8,5 @@ public interface IQueryUserRepository
     Task<User?> GetByProvider(string provider, string providerId, CancellationToken ct);
     Task<User?> GetByEmail(string email, CancellationToken ct);
     Task<bool> IsEmailUnique(string requestEmail, CancellationToken ct);
+    Task<bool> IsUsernameUnique(string username, CancellationToken ct);
 }

--- a/CoffeePeek.Account.Domain/Entities/UserAggregate/User.cs
+++ b/CoffeePeek.Account.Domain/Entities/UserAggregate/User.cs
@@ -65,14 +65,17 @@ public class User : AggregateRoot<Guid>
         return user;
     }
 
-    public static User CreateExternal(string invalidEmail, string provider, string providerId)
+    public static User CreateExternal(string invalidEmail, string provider, string providerId, string? usernameOverride = null)
     {
         var email = Email.Create(invalidEmail);
         var userId = Guid.NewGuid();
+        var username = usernameOverride is null
+            ? SanitizeUsernameFromEmail(email.Value)
+            : usernameOverride;
         return new User
         {
             Id = userId,
-            Username = Username.Create(SanitizeUsernameFromEmail(email.Value)),
+            Username = Username.Create(username),
             Credentials = UserCredential.CreateExternal(email, provider, providerId),
             Statistics = UserStatistics.Empty()
         };
@@ -204,6 +207,7 @@ public class User : AggregateRoot<Guid>
     public void ChangePassword(string newHash)
     {
         Credentials = Credentials.ChangePassword(newHash);
+        RevokeAllSessions();
     }
 
     public void BeginPasswordReset()

--- a/CoffeePeek.Account.Infrastructure/Consumers/CheckinCreatedHandler.cs
+++ b/CoffeePeek.Account.Infrastructure/Consumers/CheckinCreatedHandler.cs
@@ -6,12 +6,12 @@ namespace CoffeePeek.Account.Infrastructure.Consumers;
 
 public class CheckinCreatedHandler(IUserRepository userRepository, IUnitOfWork unitOfWork)
 {
-    public async Task Handle(CheckinCreatedEvent message)
+    public async Task Handle(CheckinCreatedEvent message, CancellationToken ct)
     {
-        var user = await userRepository.GetById(message.UserId)
+        var user = await userRepository.GetById(message.UserId, ct)
             ?? throw new InvalidOperationException($"User {message.UserId} not found for check-in event");
 
         user.Statistics.IncrementCheckIn();
-        await unitOfWork.SaveChangesAsync();
+        await unitOfWork.SaveChangesAsync(ct);
     }
 }

--- a/CoffeePeek.Account.Infrastructure/Consumers/PasswordResetRequestedEventHandler.cs
+++ b/CoffeePeek.Account.Infrastructure/Consumers/PasswordResetRequestedEventHandler.cs
@@ -12,7 +12,7 @@ public class PasswordResetRequestedEventHandler(
     IEmailTemplateService templateService,
     ILogger<PasswordResetRequestedEventHandler> logger)
 {
-    public async Task Handle(PasswordResetRequestedInternalEvent @event)
+    public async Task Handle(PasswordResetRequestedInternalEvent @event, CancellationToken ct)
     {
         var resetUrl =
             $"{config["WebClientUrl"]}/reset-password?token={Uri.EscapeDataString(@event.ResetToken)}";
@@ -27,7 +27,7 @@ public class PasswordResetRequestedEventHandler(
 
         try
         {
-            await resend.EmailSendAsync(message);
+            await resend.EmailSendAsync(message, ct);
             logger.LogInformation("Password reset email sent to {Email}", @event.Email);
         }
         catch (ResendException e)

--- a/CoffeePeek.Account.Infrastructure/Consumers/ReviewAddedHandler.cs
+++ b/CoffeePeek.Account.Infrastructure/Consumers/ReviewAddedHandler.cs
@@ -6,12 +6,12 @@ namespace CoffeePeek.Account.Infrastructure.Consumers;
 
 public class ReviewAddedHandler(IUserRepository userRepository, IUnitOfWork unitOfWork)
 {
-    public async Task Handle(ReviewAddedEvent message)
+    public async Task Handle(ReviewAddedEvent message, CancellationToken ct)
     {
-        var user = await userRepository.GetById(message.UserId)
+        var user = await userRepository.GetById(message.UserId, ct)
             ?? throw new InvalidOperationException($"User {message.UserId} not found for review-added event");
 
         user.Statistics.IncrementReviews();
-        await unitOfWork.SaveChangesAsync();
+        await unitOfWork.SaveChangesAsync(ct);
     }
 }

--- a/CoffeePeek.Account.Infrastructure/Consumers/UserPhotoUploadedHandler.cs
+++ b/CoffeePeek.Account.Infrastructure/Consumers/UserPhotoUploadedHandler.cs
@@ -7,9 +7,9 @@ namespace CoffeePeek.Account.Infrastructure.Consumers;
 
 public class UserPhotoUploadedHandler(IUserRepository userRepository, IUnitOfWork unitOfWork)
 {
-    public async Task Handle(PhotoUploadedEvent message)
+    public async Task Handle(PhotoUploadedEvent message, CancellationToken ct)
     {
-        var user = await userRepository.GetById(message.OwnerId);
+        var user = await userRepository.GetById(message.OwnerId, ct);
 
         if (user == null) return;
 
@@ -21,6 +21,6 @@ public class UserPhotoUploadedHandler(IUserRepository userRepository, IUnitOfWor
             
         user.UpdateAvatar(photo);
 
-        await unitOfWork.SaveChangesAsync();
+        await unitOfWork.SaveChangesAsync(ct);
     }
 }

--- a/CoffeePeek.Account.Infrastructure/Consumers/UserRegisteredEventHandler.cs
+++ b/CoffeePeek.Account.Infrastructure/Consumers/UserRegisteredEventHandler.cs
@@ -12,7 +12,7 @@ public class UserRegisteredEventHandler(
     IEmailTemplateService templateService,
     ILogger<UserRegisteredEventHandler> logger)
 {
-    public async Task Handle(UserRegisteredInternalEvent @event)
+    public async Task Handle(UserRegisteredInternalEvent @event, CancellationToken ct)
     {
         // Query param is read by the SPA; hash-only links remain supported on the frontend.
         var confirmationUrl =
@@ -28,7 +28,7 @@ public class UserRegisteredEventHandler(
 
         try
         {
-            await resend.EmailSendAsync(message);
+            await resend.EmailSendAsync(message, ct);
             logger.LogInformation("Confirmation email sent to {Email}", @event.Email);
         }
         catch (ResendException e)

--- a/CoffeePeek.Account.Persistence/Repositories/QueryUserRepository.cs
+++ b/CoffeePeek.Account.Persistence/Repositories/QueryUserRepository.cs
@@ -39,4 +39,9 @@ public class QueryUserRepository(AccountDbContext dbContext) : IQueryUserReposit
     {
         return !await _repository.AnyAsync(c => c.Credentials.Email == email, ct);
     }
+
+    public async Task<bool> IsUsernameUnique(string username, CancellationToken ct)
+    {
+        return !await _repository.AnyAsync(u => u.Username == username, ct);
+    }
 }

--- a/CoffeePeek.AccountService/Controllers/TokensController.cs
+++ b/CoffeePeek.AccountService/Controllers/TokensController.cs
@@ -61,6 +61,9 @@ public class TokensController(
 
         var response = await bus.InvokeAsync<Response<GoogleLoginResponse>>(command);
 
+        if (!response.IsSuccess)
+            return StatusCode(response.StatusCode ?? StatusCodes.Status400BadRequest, response);
+
         if (response.IsSuccess && response.Data is not null)
             Response.Cookies.Append("refreshToken", response.Data.RefreshToken, CreateRefreshTokenCookieOptions());
 

--- a/CoffeePeek.AccountService/Controllers/UsersController.cs
+++ b/CoffeePeek.AccountService/Controllers/UsersController.cs
@@ -32,13 +32,13 @@ public class UsersController(IMessageBus bus, IUserContext userContext) : Contro
     /// Get user profile by id or current user profile
     /// </summary>
     [HttpGet("{id:guid}")]
-    [ProducesResponseType<Response<UserProfileResponse>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<Response<PublicUserProfileResponse>>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetById(Guid? id)
     {
         var command = new GetPublicUserProfileCommand(id ?? userContext.GetUserIdOrThrow());
-        var response = await bus.InvokeAsync<Response<UserProfileResponse>>(command);
+        var response = await bus.InvokeAsync<Response<PublicUserProfileResponse>>(command);
         return Ok(response);
     }
 
@@ -46,14 +46,13 @@ public class UsersController(IMessageBus bus, IUserContext userContext) : Contro
     /// Check if user exists by email
     /// </summary>
     [HttpGet("exists")]
-    [ProducesResponseType<Response>(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<Response<bool>>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> CheckUser([FromQuery] string email)
     {
         var request = new CheckUserExistsByEmailCommand(email);
 
-        var response = await bus.InvokeAsync<Response>(request);
+        var response = await bus.InvokeAsync<Response<bool>>(request);
 
         return Ok(response);
     }
@@ -83,7 +82,7 @@ public class UsersController(IMessageBus bus, IUserContext userContext) : Contro
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetById()
     {
-        var request = new GetPublicUserProfileCommand(userContext.GetUserIdOrThrow());
+        var request = new GetProfileCommand(userContext.GetUserIdOrThrow());
         var response = await bus.InvokeAsync<Response<UserProfileResponse>>(request);
         return Ok(response);
     }
@@ -183,13 +182,14 @@ public class UsersController(IMessageBus bus, IUserContext userContext) : Contro
     [HttpDelete("me")]
     [Authorize]
     [ProducesResponseType<Response<bool>>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> DeleteUser(CancellationToken cancellationToken)
     {
         var request = new DeleteUserCommand(userContext.GetUserIdOrThrow());
         var response = await bus.InvokeAsync<Response<bool>>(request, cancellationToken);
-        
-        return Ok(response);
+
+        return response.IsSuccess ? Ok(response) : NotFound(response);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Login: unknown email and wrong password both return 401 `Invalid credentials` (no 404 enumeration).
- Public `GET /api/Users/{id}` no longer returns email; `/me` still does.
- Google login rejects unverified emails; username collisions get a unique suffix.
- Password change and self-delete revoke refresh sessions; failed Google login / delete map to 4xx.

## Test plan
- [ ] Login with unknown email → 401, same body as wrong password
- [ ] `GET /api/Users/exists?email=` for missing user → 200 `false`, not 404
- [ ] Unauthenticated `GET /api/Users/{id}` JSON has no `email`
- [ ] Authenticated `GET /api/Users/me` still includes `email`
- [ ] Google login with unverified email → 400
- [ ] Change password / delete account → existing refresh cookie no longer works


Made with [Cursor](https://cursor.com)