### PR TITLE
Dev

### DIFF
--- a/CoffeePeek.Moderation.Domain.Tests/Aggregates/ShopImportCandidateTests.cs
+++ b/CoffeePeek.Moderation.Domain.Tests/Aggregates/ShopImportCandidateTests.cs
@@ -241,6 +241,20 @@ public class ShopImportCandidateTests
         candidate.QueueStatus.Should().Be(ImportQueueStatus.Published);
     }
 
+    [Fact]
+    public void GetResearchLinks_WithUnicodeName_BuildsAbsoluteUrls()
+    {
+        var candidate = ShopImportCandidate.FromOsm(Snapshot("node/3032203937", "Кофейня «Ёлка» ☕"), Now);
+
+        var links = candidate.GetResearchLinks();
+
+        links.GoogleMaps.Should().StartWith("https://");
+        links.YandexMaps.Should().StartWith("https://");
+        links.YandexImages.Should().StartWith("https://");
+        links.OsmHistory.Should().Be("https://www.openstreetmap.org/node/3032203937/history");
+        links.InstagramSearch.Should().Contain("instagram");
+    }
+
     private static OsmCandidateSnapshot Snapshot(
         string externalId,
         string? name,

--- a/CoffeePeek.Shared.Persistence/Extensions/DatabaseModule.cs
+++ b/CoffeePeek.Shared.Persistence/Extensions/DatabaseModule.cs
@@ -2,6 +2,7 @@ using CoffeePeek.Shared.Kernel;
 using CoffeePeek.Shared.Persistence.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
 
 namespace CoffeePeek.Shared.Persistence.Extensions;
 
@@ -15,7 +16,12 @@ public static class DatabaseModule
     {
         services.AddDbContext<TDbContext>(opt =>
         {
-            opt.UseNpgsql(connectionString);
+            // jsonb collections (List<string> Signals/TagSlugs) require dynamic JSON on the
+            // Npgsql data source. Without it, materializing ShopImportCandidates throws
+            // InvalidCastException and YARP surfaces the aborted response as HTTP 502.
+            opt.UseNpgsql(
+                connectionString,
+                npgsql => npgsql.ConfigureDataSource(ds => ds.EnableDynamicJson()));
             configure?.Invoke(opt);
         });
 

--- a/CoffeePeek.Shops.Application.Tests/Features/CoffeeShop/SearchCoffeeShopsHandlerTests.cs
+++ b/CoffeePeek.Shops.Application.Tests/Features/CoffeeShop/SearchCoffeeShopsHandlerTests.cs
@@ -33,6 +33,7 @@ public class SearchCoffeeShopsHandlerTests
             CoffeeShops = [shop],
             TotalItems = 1,
             CurrentPage = 1,
+            PageSize = 10,
             TotalPages = 1
         };
 
@@ -118,6 +119,36 @@ public class SearchCoffeeShopsHandlerTests
 
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().Contain("Failed to retrieve");
+    }
+
+    [Fact]
+    public async Task Handle_WhenCacheMiss_SetsPageSizeOnResponse()
+    {
+        var shop = new ShortShopDto { Id = Guid.NewGuid(), Name = "Test Shop" };
+        _shopQueriesMock
+            .Setup(q => q.Search(It.IsAny<SearchCoffeeShopsQuery>(), _ct))
+            .ReturnsAsync(([shop], 1));
+
+        _cacheMock
+            .Setup(c => c.GetAsync(
+                It.IsAny<CacheKey>(),
+                It.IsAny<Func<CancellationToken, Task<GetCoffeeShopsResponse>>>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns((CacheKey _, Func<CancellationToken, Task<GetCoffeeShopsResponse>> factory, TimeSpan? _, CancellationToken ct) => factory(ct));
+
+        var query = new SearchCoffeeShopsQuery(PageNumber: 1, PageSize: 10);
+        var result = await SearchCoffeeShopsHandler.Handle(
+            query,
+            _shopQueriesMock.Object,
+            _visitRepoMock.Object,
+            _cacheMock.Object,
+            _ct);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data.PageSize.Should().Be(10);
+        result.Data.CurrentPage.Should().Be(1);
+        result.Data.TotalItems.Should().Be(1);
     }
 
     [Fact]

--- a/CoffeePeek.Shops.Application/Features/CoffeeShop/SearchCoffeeShops/SearchCoffeeShopsHandler.cs
+++ b/CoffeePeek.Shops.Application/Features/CoffeeShop/SearchCoffeeShops/SearchCoffeeShopsHandler.cs
@@ -28,7 +28,10 @@ public class SearchCoffeeShopsHandler
                 CoffeeShops = items,
                 TotalItems = totalCount,
                 CurrentPage = queryRequest.PageNumber,
-                TotalPages = (int)Math.Ceiling(totalCount / (double)queryRequest.PageSize)
+                PageSize = queryRequest.PageSize,
+                TotalPages = queryRequest.PageSize <= 0
+                    ? 0
+                    : (int)Math.Ceiling(totalCount / (double)queryRequest.PageSize)
             };
         }, cancellationToken: ct);
         

--- a/CoffeePeek.ShopsService/Controllers/CoffeeShopsController.cs
+++ b/CoffeePeek.ShopsService/Controllers/CoffeeShopsController.cs
@@ -45,7 +45,7 @@ public class CoffeeShopsController(IMessageBus bus, IUserContext userContext) : 
         [FromQuery] Contract.Enums.CoffeeFocus? coffeeFocus = null,
         [FromQuery][Range(0, 5)] decimal? minRating = null,
         [FromQuery][Range(1, int.MaxValue)] int page = 1,
-        [FromQuery][Range(1, 100)] int pageSize = 10)
+        [FromQuery][Range(0, 100)] int pageSize = 10)
     {
         page = Math.Max(1, page);
         pageSize = pageSize <= 0 ? 10 : Math.Min(pageSize, 100);
@@ -82,7 +82,7 @@ public class CoffeeShopsController(IMessageBus bus, IUserContext userContext) : 
             Response.Headers.TryAdd("X-Total-Count", data.TotalItems.ToString());
             Response.Headers.TryAdd("X-Total-Pages", data.TotalPages.ToString());
             Response.Headers.TryAdd("X-Current-Page", data.CurrentPage.ToString());
-            Response.Headers.TryAdd("X-Page-Size", data.PageSize.ToString());
+            Response.Headers.TryAdd("X-Page-Size", (data.PageSize > 0 ? data.PageSize : pageSize).ToString());
         }
     }
 

--- a/CoffeeShop.Moderation.Persistence/Configuration/ModerationDbContextFactory.cs
+++ b/CoffeeShop.Moderation.Persistence/Configuration/ModerationDbContextFactory.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Configuration;
+using Npgsql;
 
 namespace CoffeeShop.Moderation.Persistence.Configuration;
 
@@ -24,7 +25,9 @@ public class ModerationDbContextFactory : IDesignTimeDbContextFactory<Moderation
             throw new InvalidOperationException("ConnectionString not found in environment variables.");
         }
 
-        optionsBuilder.UseNpgsql(connectionString);
+        optionsBuilder.UseNpgsql(
+            connectionString,
+            npgsql => npgsql.ConfigureDataSource(ds => ds.EnableDynamicJson()));
 
         return new ModerationDbContext(optionsBuilder.Options);
     }

--- a/CoffeeShop.Moderation.Persistence/Configuration/ShopImportCandidateConfiguration.cs
+++ b/CoffeeShop.Moderation.Persistence/Configuration/ShopImportCandidateConfiguration.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using CoffeePeek.Moderation.Domain.Aggregates.ShopImportCandidateAggregate;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -8,8 +7,6 @@ namespace CoffeeShop.Moderation.Persistence.Configuration;
 
 public class ShopImportCandidateConfiguration : IEntityTypeConfiguration<ShopImportCandidate>
 {
-    private static readonly JsonSerializerOptions JsonOptions = new();
-
     public void Configure(EntityTypeBuilder<ShopImportCandidate> entity)
     {
         entity.ToTable("ShopImportCandidates");
@@ -29,18 +26,15 @@ public class ShopImportCandidateConfiguration : IEntityTypeConfiguration<ShopImp
         entity.Property(e => e.Latitude).HasPrecision(18, 10);
         entity.Property(e => e.Longitude).HasPrecision(18, 10);
 
-        entity.Property(e => e.Signals)
+        // Npgsql 10 maps List<string> + jsonb natively. Do not convert through string:
+        // reading jsonb as System.String requires EnableDynamicJson and aborts the reader
+        // when it is missing (Gateway then returns 502 for GET /api/admin/import/candidates).
+        entity.PrimitiveCollection(e => e.Signals)
             .HasColumnType("jsonb")
-            .HasConversion(
-                v => JsonSerializer.Serialize(v, JsonOptions),
-                v => JsonSerializer.Deserialize<List<string>>(v, JsonOptions) ?? new List<string>())
             .Metadata.SetValueComparer(StringListComparer());
 
-        entity.Property(e => e.TagSlugs)
+        entity.PrimitiveCollection(e => e.TagSlugs)
             .HasColumnType("jsonb")
-            .HasConversion(
-                v => JsonSerializer.Serialize(v, JsonOptions),
-                v => JsonSerializer.Deserialize<List<string>>(v, JsonOptions) ?? new List<string>())
             .Metadata.SetValueComparer(StringListComparer());
 
         entity.HasIndex(e => new { e.Source, e.ExternalId }).IsUnique();
@@ -53,6 +47,6 @@ public class ShopImportCandidateConfiguration : IEntityTypeConfiguration<ShopImp
     private static ValueComparer<List<string>> StringListComparer() =>
         new(
             (a, b) => a != null && b != null && a.SequenceEqual(b),
-            v => v.Aggregate(0, (hash, item) => HashCode.Combine(hash, item.GetHashCode())),
+            v => v.Aggregate(0, (hash, item) => HashCode.Combine(hash, item != null ? item.GetHashCode() : 0)),
             v => v.ToList());
 }


### PR DESCRIPTION
## Summary
- Fix admin import candidates 502: map jsonb `Signals`/`TagSlugs` natively and enable Npgsql dynamic JSON
- Fix coffee shop list 400: set `PageSize` on search response so clients stop sending `pageSize=0`

## Test plan
- [ ] `GET /api/admin/import/candidates?status=0&bucket=0&page=1&pageSize=20` returns 200
- [ ] Coffee shop list pagination past page 1 no longer 400s


Made with [Cursor](https://cursor.com)