### PR TITLE
Dev

### DIFF
--- a/CoffeePeek.Shops.Application.Tests/Features/CheckIn/CreateCheckInHandlerTests.cs
+++ b/CoffeePeek.Shops.Application.Tests/Features/CheckIn/CreateCheckInHandlerTests.cs
@@ -13,6 +13,7 @@ using FluentAssertions;
 using MapsterMapper;
 using Moq;
 using Wolverine;
+using DomainCheckIn = CoffeePeek.Shops.Domain.Aggregates.CheckInAggregate.CheckIn;
 
 namespace CoffeePeek.Shops.Application.Tests.Features.CheckIn.CreateCheckIn;
 
@@ -77,6 +78,10 @@ public class CreateCheckInHandlerTests
         _mapperMock.Setup(m => m.Map<CoffeePeek.Contract.Dtos.CoffeeShop.ReviewDto>(It.IsAny<object>()))
             .Returns(new CoffeePeek.Contract.Dtos.CoffeeShop.ReviewDto());
 
+        DomainCheckIn? saved = null;
+        _checkInRepoMock.Setup(r => r.Add(It.IsAny<DomainCheckIn>()))
+            .Callback<DomainCheckIn>(c => saved = c);
+
         var result = await CreateCheckInHandler.Handle(
             command,
             _checkInRepoMock.Object,
@@ -88,6 +93,10 @@ public class CreateCheckInHandlerTests
             _ct);
 
         result.IsSuccess.Should().BeTrue();
+        saved.Should().NotBeNull();
+        saved!.Rating.Place.Should().Be(3);
+        saved.Rating.Service.Should().Be(4);
+        saved.Rating.Coffee.Should().Be(5);
         _busMock.Verify(b => b.PublishAsync(It.IsAny<object>()), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(_ct), Times.Once);
     }

--- a/CoffeePeek.Shops.Application/Features/CheckIn/CreateCheckIn/CreateCheckInHandler.cs
+++ b/CoffeePeek.Shops.Application/Features/CheckIn/CreateCheckIn/CreateCheckInHandler.cs
@@ -49,6 +49,9 @@ public static class CreateCheckInHandler
 
         if (command.IsPublic)
         {
+            // Owned Rating columns on CheckIns are NOT NULL — persist the public rating
+            // before SaveChanges or Postgres rejects the insert as a generic CONFLICT.
+            checkIn.AssignRating(command.Rating!.Place, command.Rating.Service, command.Rating.Coffee);
             queryCheckInRepository.Add(checkIn);
 
             try
@@ -62,7 +65,7 @@ public static class CreateCheckInHandler
                     command.UserName,
                     header: commentPreview,
                     comment: command.Note!,
-                    ratingPlace: command.Rating!.Place, 
+                    ratingPlace: command.Rating.Place, 
                     ratingService: command.Rating.Service, 
                     ratingCoffee: command.Rating.Coffee);
 

--- a/CoffeePeek.Shops.Domain.Tests/Aggregates/CheckInAggregate/CheckInTests.cs
+++ b/CoffeePeek.Shops.Domain.Tests/Aggregates/CheckInAggregate/CheckInTests.cs
@@ -47,6 +47,19 @@ public class CheckInTests
     }
 
     [Fact]
+    public void AssignRating_WithValidScores_SetsOwnedRating()
+    {
+        var checkIn = CheckIn.Create(Guid.NewGuid(), Guid.NewGuid(), DateTime.UtcNow.AddHours(-1));
+
+        checkIn.AssignRating(place: 5, service: 4, coffee: 3);
+
+        checkIn.Rating.Place.Should().Be(5);
+        checkIn.Rating.Service.Should().Be(4);
+        checkIn.Rating.Coffee.Should().Be(3);
+        checkIn.Rating.AverageRating.Should().Be(4m);
+    }
+
+    [Fact]
     public void UpdateNote_WithValue_SetsNote()
     {
         // Arrange

--- a/CoffeePeek.Shops.Domain/Aggregates/CheckInAggregate/CheckInAction.cs
+++ b/CoffeePeek.Shops.Domain/Aggregates/CheckInAggregate/CheckInAction.cs
@@ -13,6 +13,11 @@ public partial class CheckIn
         return new CheckIn(userId, shopId, visitedAt);
     }
 
+    public void AssignRating(int place, int service, int coffee)
+    {
+        Rating = Rating.Create(place, service, coffee);
+    }
+
     public void UpdateNote(string? newNote)
     {
         Note = newNote?.Trim();


### PR DESCRIPTION
## Summary
- Persist the public check-in rating onto the CheckIn aggregate so Postgres NOT NULL Rating_* columns no longer reject the insert as CONFLICT

## Test plan
- [ ] POST /api/CheckIns with isPublic=true and a rating returns 200
- [ ] Repeat check-in to the same shop still succeeds (index is not unique)


Made with [Cursor](https://cursor.com)