### PR TITLE
Dev

### DIFF
--- a/CoffeePeek.Shops.Application.Tests/Features/CoffeeShop/SearchCoffeeShopsHandlerTests.cs
+++ b/CoffeePeek.Shops.Application.Tests/Features/CoffeeShop/SearchCoffeeShopsHandlerTests.cs
@@ -152,6 +152,39 @@ public class SearchCoffeeShopsHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WhenCachedResponseOmitsPageSize_CopiesItFromQuery()
+    {
+        var shop = new ShortShopDto { Id = Guid.NewGuid(), Name = "Test Shop" };
+        var staleCache = new GetCoffeeShopsResponse
+        {
+            CoffeeShops = [shop],
+            TotalItems = 1,
+            CurrentPage = 1,
+            PageSize = 0,
+            TotalPages = 1
+        };
+
+        _cacheMock
+            .Setup(c => c.GetAsync(
+                It.IsAny<CacheKey>(),
+                It.IsAny<Func<CancellationToken, Task<GetCoffeeShopsResponse>>>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(staleCache);
+
+        var query = new SearchCoffeeShopsQuery(PageNumber: 1, PageSize: 10);
+        var result = await SearchCoffeeShopsHandler.Handle(
+            query,
+            _shopQueriesMock.Object,
+            _visitRepoMock.Object,
+            _cacheMock.Object,
+            _ct);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data.PageSize.Should().Be(10);
+    }
+
+    [Fact]
     public void CreateSearchHash_IncludesTagsAndComputedFilters()
     {
         var tagA = Guid.Parse("11111111-1111-1111-1111-111111111111");

--- a/CoffeePeek.Shops.Application/Features/CoffeeShop/SearchCoffeeShops/SearchCoffeeShopsHandler.cs
+++ b/CoffeePeek.Shops.Application/Features/CoffeeShop/SearchCoffeeShops/SearchCoffeeShopsHandler.cs
@@ -29,13 +29,15 @@ public class SearchCoffeeShopsHandler
                 TotalItems = totalCount,
                 CurrentPage = queryRequest.PageNumber,
                 PageSize = queryRequest.PageSize,
-                TotalPages = queryRequest.PageSize <= 0
-                    ? 0
-                    : (int)Math.Ceiling(totalCount / (double)queryRequest.PageSize)
+                TotalPages = (int)Math.Ceiling(totalCount / (double)queryRequest.PageSize)
             };
         }, cancellationToken: ct);
         
         if (cachedResponse == null) return Response<GetCoffeeShopsResponse>.Error("Failed to retrieve coffee shop search results");
+
+        // Old cache entries omitted PageSize (defaulted to 0). Echo the requested size so
+        // clients never paginate with pageSize=0.
+        cachedResponse.PageSize = queryRequest.PageSize;
 
         if (queryRequest.UserId.HasValue)
         {

--- a/CoffeePeek.ShopsService/Controllers/CatalogsController.cs
+++ b/CoffeePeek.ShopsService/Controllers/CatalogsController.cs
@@ -12,6 +12,7 @@ namespace CoffeePeek.ShopsService.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[ResponseCache(Duration = 3600, Location = ResponseCacheLocation.Any)]
 [ProducesErrorResponseType(typeof(ErrorResponse))]
 public class CatalogsController(IMessageBus bus) : ControllerBase
 {

--- a/CoffeePeek.ShopsService/Controllers/CoffeeShopsController.cs
+++ b/CoffeePeek.ShopsService/Controllers/CoffeeShopsController.cs
@@ -45,7 +45,7 @@ public class CoffeeShopsController(IMessageBus bus, IUserContext userContext) : 
         [FromQuery] Contract.Enums.CoffeeFocus? coffeeFocus = null,
         [FromQuery][Range(0, 5)] decimal? minRating = null,
         [FromQuery][Range(1, int.MaxValue)] int page = 1,
-        [FromQuery][Range(0, 100)] int pageSize = 10)
+        [FromQuery][Range(1, 100)] int pageSize = 10)
     {
         page = Math.Max(1, page);
         pageSize = pageSize <= 0 ? 10 : Math.Min(pageSize, 100);
@@ -82,7 +82,7 @@ public class CoffeeShopsController(IMessageBus bus, IUserContext userContext) : 
             Response.Headers.TryAdd("X-Total-Count", data.TotalItems.ToString());
             Response.Headers.TryAdd("X-Total-Pages", data.TotalPages.ToString());
             Response.Headers.TryAdd("X-Current-Page", data.CurrentPage.ToString());
-            Response.Headers.TryAdd("X-Page-Size", (data.PageSize > 0 ? data.PageSize : pageSize).ToString());
+            Response.Headers.TryAdd("X-Page-Size", data.PageSize.ToString());
         }
     }
 


### PR DESCRIPTION
## Summary
- Keep coffee shop `pageSize` in 1–100; copy it from the query onto cached search results so page 2 cannot send `pageSize=0`
- Cache public catalog GETs (`Cache-Control` 1 hour) so cities/equipment/etc. skip the Caddy→YARP→Shops hop

## Test plan
- [ ] Coffee shop list page 2 with a valid `pageSize` returns 200; `pageSize=0` returns 400
- [ ] `GET /api/Catalogs/cities` includes `Cache-Control: public, max-age=3600`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые возможности**
  - Добавлено кэширование ответов каталога на срок до 1 часа.
  - Улучшена обработка кэшированных результатов поиска кофеен: размер страницы теперь корректно соответствует текущему запросу.

- **Исправления**
  - Параметр размера страницы принимает значения от 1 до 100.
  - Заголовок `X-Page-Size` теперь всегда отражает фактический размер страницы в ответе.
  - Расчёт общего количества страниц стал стабильнее для различных запросов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->