### PR TITLE
Always expose OpenAPI endpoints for all services

### DIFF
--- a/CoffeePeek.AccountService/InfrastructureExtensions.cs
+++ b/CoffeePeek.AccountService/InfrastructureExtensions.cs
@@ -42,10 +42,7 @@ public static class InfrastructureExtensions
         app.UseAuthentication();
         app.UseAuthorization();
 
-        if (app.Environment.IsDevelopment())
-        {
-            app.MapOpenApi();
-        }
+        app.MapOpenApi();
         
         app.MapDefaultEndpoints();
 

--- a/CoffeePeek.MediaService/Program.cs
+++ b/CoffeePeek.MediaService/Program.cs
@@ -68,10 +68,7 @@ builder.AddWolverine([handlersAssembly]);
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
-{
-    app.MapOpenApi();
-}
+app.MapOpenApi();
 
 app.UseExceptionHandler();
 app.MapControllers();

--- a/CoffeePeek.ModerationService/InfrastructureExtensions.cs
+++ b/CoffeePeek.ModerationService/InfrastructureExtensions.cs
@@ -41,10 +41,7 @@ public static class InfrastructureExtensions
         app.UseAuthentication();
         app.UseAuthorization();
 
-        if (app.Environment.IsDevelopment())
-        {
-            app.MapOpenApi();
-        }
+        app.MapOpenApi();
 
         app.MapDefaultEndpoints();
 

--- a/CoffeePeek.ShopsService/InfrastructureExtensions.cs
+++ b/CoffeePeek.ShopsService/InfrastructureExtensions.cs
@@ -40,10 +40,7 @@ public static class InfrastructureExtensions
         app.UseExceptionHandler();
         app.UseResponseCaching();
 
-        if (app.Environment.IsDevelopment())
-        {
-            app.MapOpenApi();
-        }
+        app.MapOpenApi();
 
         app.MapDefaultEndpoints();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove `Environment.IsDevelopment()` guards around `MapOpenApi()` in Account, Shops, Moderation, and Media services
- keep OpenAPI documents available in all environments so Gateway Scalar can always load downstream specs

## Changed files
- `CoffeePeek.AccountService/InfrastructureExtensions.cs`
- `CoffeePeek.ShopsService/InfrastructureExtensions.cs`
- `CoffeePeek.ModerationService/InfrastructureExtensions.cs`
- `CoffeePeek.MediaService/Program.cs`

## Validation plan
- build affected service projects to verify startup pipeline changes compile
- run a local smoke check for `/openapi/v1.json` on each service (when services are running)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5396cfe-b337-47d8-bdf1-b24df20f9af4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5396cfe-b337-47d8-bdf1-b24df20f9af4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * OpenAPI-документация теперь доступна во всех окружениях для сервисов аккаунтов, медиа, модерации и магазинов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->