### PR TITLE
Serialize API enums as strings globally

### DIFF
--- a/CoffeePeek.MediaService/Program.cs
+++ b/CoffeePeek.MediaService/Program.cs
@@ -15,12 +15,17 @@ using CoffeePeek.Shared.Persistence.Extensions;
 using CoffeePeek.Shared.Web;
 using CoffeePeek.Shared.Web.Handlers;
 using CoffeePeek.Shared.Web.Sentry;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.WebHost.UseCoffeePeekSentry();
 var services = builder.Services;
 
-services.AddControllers();
+services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 services.AddProblemDetails();
 services.AddExceptionHandler<GlobalExceptionHandler>();
 services.AddHeaderUserContext(builder.Configuration);

--- a/CoffeePeek.Shared.Web/Extensions/ControllersModule.cs
+++ b/CoffeePeek.Shared.Web/Extensions/ControllersModule.cs
@@ -2,6 +2,7 @@ using CoffeePeek.Shared.Kernel.ErrorCodes;
 using CoffeePeek.Shared.Kernel.Response;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using System.Text.Json.Serialization;
 
 namespace CoffeePeek.Shared.Web.Extensions;
 
@@ -9,7 +10,12 @@ public static class ControllersModule
 {
     public static IServiceCollection AddControllersModule(this IServiceCollection services)
     {
-        services.AddControllers();
+        services
+            .AddControllers()
+            .AddJsonOptions(options =>
+            {
+                options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+            });
         services.AddEndpointsApiExplorer();
 
         // Map ASP.NET model binding / data annotation errors to our ErrorResponse format


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- configure controller JSON serialization to use `JsonStringEnumConverter` in shared `AddControllersModule()`
- apply the same enum-as-string JSON converter in `CoffeePeek.MediaService` (it does not use the shared controllers module)
- this makes enum values in request/response payloads string-based across all service endpoints

## Changed files
- `CoffeePeek.Shared.Web/Extensions/ControllersModule.cs`
- `CoffeePeek.MediaService/Program.cs`

## Validation
- build the affected services/projects
- run runtime serialization checks to verify enum payloads are emitted as strings

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5396cfe-b337-47d8-bdf1-b24df20f9af4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5396cfe-b337-47d8-bdf1-b24df20f9af4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

