### PR TITLE
Fix Moderation OpenAPI 500 in Scalar

### DIFF
--- a/CoffeePeek.ModerationService/Controllers/AdminImportController.cs
+++ b/CoffeePeek.ModerationService/Controllers/AdminImportController.cs
@@ -90,7 +90,7 @@ public class AdminImportController(IMessageBus bus, IUserContext userContext) : 
 
     [HttpGet("candidates/{id:guid}")]
     [ProducesResponseType<Response<ShopImportCandidateDto>>(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetCandidate(Guid id, CancellationToken ct)
     {
         var response = await bus.InvokeAsync<Response<ShopImportCandidateDto>>(

--- a/CoffeePeek.ModerationService/Controllers/ModerationReviewsController.cs
+++ b/CoffeePeek.ModerationService/Controllers/ModerationReviewsController.cs
@@ -22,8 +22,8 @@ public class ModerationReviewsController(IMessageBus bus, IUserContext userConte
     [HttpGet]
     [Authorize(Policy = RoleConsts.Moderator)]
     [ProducesResponseType(typeof(Response<GetAllModerationReviewsResponse>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status503ServiceUnavailable)]
     public async Task<IActionResult> GetAllModerationReviews(
         [FromQuery] GetAllModerationReviewsQuery query,
         CancellationToken cancellationToken)
@@ -44,7 +44,7 @@ public class ModerationReviewsController(IMessageBus bus, IUserContext userConte
     [HttpGet("{id:guid}")]
     [Authorize(Policy = RoleConsts.Moderator)]
     [ProducesResponseType<Response<ModerationReviewDto>>(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetModerationReviewById(Guid id, CancellationToken ct)
     {
         var response = await bus.InvokeAsync<Response<ModerationReviewDto>>(new GetModerationReviewByIdQuery(id), ct);
@@ -54,10 +54,10 @@ public class ModerationReviewsController(IMessageBus bus, IUserContext userConte
     [HttpPost]
     [Authorize]
     [ProducesResponseType(typeof(CreateEntityResponse), statusCode: StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status503ServiceUnavailable)]
     public async Task<IActionResult> SendReviewToModeration(
         [FromBody] SendReviewToModerationCommand command, CancellationToken ct)
     {
@@ -77,10 +77,10 @@ public class ModerationReviewsController(IMessageBus bus, IUserContext userConte
     [HttpPut("{reviewId:guid}")]
     [Authorize]
     [ProducesResponseType(typeof(Response<UpdateCoffeeShopReviewResponse>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> UpdateReview(
         [FromBody] UpdateCoffeeShopReviewCommand command, Guid reviewId, CancellationToken ct)
     {
@@ -95,9 +95,9 @@ public class ModerationReviewsController(IMessageBus bus, IUserContext userConte
     [HttpPut]
     [Authorize(Policy = RoleConsts.Moderator)]
     [ProducesResponseType<UpdateEntityResponse<ModerationStatus>>(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status503ServiceUnavailable)]
     public async Task<IActionResult> ChangeStatusModerationReview(
         [FromBody] ChangeStatusModerationReviewCommand command, CancellationToken ct)
     {

--- a/CoffeePeek.ModerationService/Controllers/ModerationShopsController.cs
+++ b/CoffeePeek.ModerationService/Controllers/ModerationShopsController.cs
@@ -25,7 +25,7 @@ public class ModerationShopsController(IMessageBus bus, IUserContext userContext
     [Authorize(Policy = RoleConsts.Moderator)]
     [Description("Get coffee shops for moderation with pagination and filters")]
     [ProducesResponseType<Response<GetAllModerationShopsResponse>>(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetAllModerationShops([FromQuery] GetAllModerationShopsQuery request, CancellationToken ct)
     {
         var response = await bus.InvokeAsync<Response<GetAllModerationShopsResponse>>(request, ct);
@@ -44,7 +44,7 @@ public class ModerationShopsController(IMessageBus bus, IUserContext userContext
     [HttpGet("{id:guid}")]
     [Authorize(Policy = RoleConsts.Moderator)]
     [ProducesResponseType<Response<ModerationShopDto>>(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<ErrorResponse>(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetModerationShopById(Guid id, CancellationToken ct)
     {
         var response = await bus.InvokeAsync<Response<ModerationShopDto>>(new GetModerationShopByIdQuery(id), ct);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace untyped `ProducesResponseType(StatusCodes...)` annotations with explicit `ErrorResponse` response types in moderation controllers
- keep successful response contracts unchanged
- this avoids invalid/void response metadata in OpenAPI generation for ModerationService endpoints

## Changed files
- `CoffeePeek.ModerationService/Controllers/ModerationReviewsController.cs`
- `CoffeePeek.ModerationService/Controllers/ModerationShopsController.cs`
- `CoffeePeek.ModerationService/Controllers/AdminImportController.cs`

## Validation
- `dotnet build CoffeePeek.ModerationService/CoffeePeek.ModerationService.csproj`
- `dotnet test CoffeePeek.Moderation.Domain.Tests/CoffeePeek.Moderation.Domain.Tests.csproj`

## Note
- Production verification requires deploy/restart of moderation service and a live check of `https://api.coffeepeek.by/moderation/openapi/v1.json`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5396cfe-b337-47d8-bdf1-b24df20f9af4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5396cfe-b337-47d8-bdf1-b24df20f9af4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

